### PR TITLE
Bugfix/permissions not reflected to page behavior #46

### DIFF
--- a/core/permissions/checker.py
+++ b/core/permissions/checker.py
@@ -1,6 +1,8 @@
 """
 Module that handle permission management.
 """
+import logging
+
 from abc import ABCMeta, abstractmethod
 
 from django.contrib.contenttypes.models import ContentType
@@ -13,6 +15,8 @@ from guardian.mixins import PermissionRequiredMixin
 
 from core import constants
 from core.exceptions import DaisyError
+
+logger = logging.getLogger('daisy.permissions')
 
 
 class AbstractChecker(metaclass=ABCMeta):
@@ -61,7 +65,9 @@ class DatasetChecker(AbstractChecker):
     """
 
     def _check(self, perm, obj, **kwargs):
-        if self.checker.has_perm(perm, obj):
+        hasperm = self.checker.has_perm(perm, obj)
+        logger.debug(f'[DatasetChecker _check] Checking permission "{perm}" on: "{obj}": {hasperm}.')
+        if hasperm:
             return True
         nofollow = kwargs.pop('nofollow', False)
         if nofollow:
@@ -156,8 +162,10 @@ class AutoChecker(AbstractChecker):
         Check the permission on the object.
         Automatically determines which permission class to use.
         """
-        return self.__mapping[obj.__class__.__name__](self.user_or_group, checker=self.checker).check(perm, obj,
+        value = self.__mapping[obj.__class__.__name__](self.user_or_group, checker=self.checker).check(perm, obj,
                                                                                                       **kwargs)
+        logger.debug(f'[AutoChecker] Checking permission "{perm}" on {obj.__class__.__name__}: "{obj}" for "{self.user_or_group}": {value}.')
+        return value
 
 
 def permission_required(perm, lookup_variables):

--- a/web/views/access.py
+++ b/web/views/access.py
@@ -2,6 +2,7 @@ from core.forms.access import AccessForm, AccessEditForm
 from web.views.utils import AjaxViewMixin
 from django.views.generic import CreateView
 from core.models import Access, Dataset
+from core.constants import Permissions
 from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib import messages
 from django.urls import reverse_lazy
@@ -48,7 +49,7 @@ class AccessCreateView(CreateView, AjaxViewMixin):
         return super().get_success_url()
 
 
-@permission_required('EDIT', (Dataset, 'pk', 'dataset_pk'))
+@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def edit_access(request, pk, dataset_pk):
     access = get_object_or_404(Access, pk=pk)
     if request.method == 'POST':
@@ -70,7 +71,7 @@ def edit_access(request, pk, dataset_pk):
     return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path() })
 
 @require_http_methods(["DELETE"])
-@permission_required('EDIT', (Dataset, 'pk', 'dataset_pk'))
+@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def remove_access(request, dataset_pk, access_pk):
     access = get_object_or_404(Access, pk=access_pk)
     dataset = get_object_or_404(Dataset, pk=dataset_pk)

--- a/web/views/contact.py
+++ b/web/views/contact.py
@@ -11,12 +11,13 @@ from core.forms import ContactForm, PickContactForm
 from core.models import Contact, Project
 from core.permissions import permission_required
 from web.views.utils import AjaxViewMixin
+from core.constants import Permissions
 from . import facet_view_utils
 FACET_FIELDS = settings.FACET_FIELDS['contact']
 from core.models.utils import COMPANY
 
 @require_http_methods(["DELETE"])
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def remove_contact_from_project(request, pk, contact_id):
     contact = get_object_or_404(Contact, pk=contact_id)
     project = get_object_or_404(Project, pk=pk)
@@ -24,7 +25,7 @@ def remove_contact_from_project(request, pk, contact_id):
     return HttpResponse("Contact deleted")
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def pick_contact_for_project(request, pk):
     if request.method == 'POST':
         form = PickContactForm(request.POST)
@@ -45,7 +46,7 @@ def pick_contact_for_project(request, pk):
     return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path()})
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def add_contact_to_project(request, pk):
     if request.method == 'POST':
         form = ContactForm(request.POST)

--- a/web/views/contracts.py
+++ b/web/views/contracts.py
@@ -146,7 +146,7 @@ def partner_role_delete(request, pk):
     return HttpResponse("Partner (signatory) removed from contract.")
 
 #
-# @permission_required('EDIT', (Contract, 'pk', 'pk'))
+# @permission_required(Permissions.EDIT, (Contract, 'pk', 'pk'))
 # def add_kv_to_contract(request, pk):
 #     if request.method == 'POST':
 #         form = KVForm(request.POST)
@@ -174,7 +174,7 @@ def partner_role_delete(request, pk):
 #     return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path()})
 #
 #
-# @permission_required('EDIT', (Contract, 'pk', 'pk'))
+# @permission_required(Permissions.EDIT, (Contract, 'pk', 'pk'))
 # def rm_kv_from_contract(request, pk, key):
 #     contract = get_object_or_404(Contract, pk=pk)
 #     metadata = contract.metadata
@@ -185,7 +185,7 @@ def partner_role_delete(request, pk):
 
 ## DATASET METHODS ##
 #
-# @permission_required('EDIT', (Collaboration, 'pk', 'pk'))
+# @permission_required(Permissions.EDIT, (Collaboration, 'pk', 'pk'))
 # def collaboration_dataset_add(request, pk):
 #     contract = get_object_or_404(Collaboration, pk=pk)
 #     if request.method == 'GET':
@@ -213,7 +213,7 @@ def partner_role_delete(request, pk):
 #         })
 #
 #
-# @permission_required('EDIT', (Collaboration, 'pk', 'pk'))
+# @permission_required(Permissions.EDIT, (Collaboration, 'pk', 'pk'))
 # def collaboration_dataset_remove(request, pk, dataset_id):
 #     # TODO: check that contract is membership with project
 #     contract = get_object_or_404(Collaboration, pk=pk)

--- a/web/views/documents.py
+++ b/web/views/documents.py
@@ -53,7 +53,7 @@ def upload_document(request, object_id, content_type):
     return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path()})
 
 
-@permission_required('EDIT', (Document, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Document, 'pk', 'pk'))
 def document_edit(request, pk):
     log.debug('editing document', post=request.POST)
     document = get_object_or_404(Document, pk=pk)

--- a/web/views/legalbasis.py
+++ b/web/views/legalbasis.py
@@ -11,6 +11,7 @@ from core.models import LegalBasis, Dataset
 from core.permissions import permission_required
 from core.utils import DaisyLogger
 from web.views.utils import AjaxViewMixin
+from core.constants import Permissions
 
 log = DaisyLogger(__name__)
 
@@ -49,7 +50,7 @@ class LegalBasisCreateView(CreateView, AjaxViewMixin):
         return reverse_lazy('dataset', kwargs={'pk': self.dataset.pk})
 
 
-@permission_required('EDIT', (Dataset, 'pk', 'dataset_pk'))
+@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def edit_legalbasis(request, pk, dataset_pk):
     # log.debug('editing legal basis', post=request.POST)
     legalbasis = get_object_or_404(LegalBasis, pk=pk)
@@ -75,7 +76,7 @@ def edit_legalbasis(request, pk, dataset_pk):
 
 
 @require_http_methods(["DELETE"])
-@permission_required('EDIT', (Dataset, 'pk', 'dataset_pk'))
+@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def remove_legalbasis(request, dataset_pk, legalbasis_pk):
     legbasis = get_object_or_404(LegalBasis, pk=legalbasis_pk)
     dataset = get_object_or_404(Dataset, pk=dataset_pk)

--- a/web/views/projects.py
+++ b/web/views/projects.py
@@ -8,6 +8,7 @@ from django.urls import reverse_lazy
 from django.views.generic import ListView, CreateView, DetailView, UpdateView, DeleteView
 
 from core import constants
+from core.constants import Permissions
 from core.forms.contract import ContractForm
 from core.forms.dataset import DatasetForm
 from core.forms.document import DocumentForm
@@ -137,7 +138,7 @@ class ProjectEditView(CheckerMixin, UpdateView):
 
 ## DATASET METHODS ##
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def project_dataset_create(request, pk, flag):
     project = get_object_or_404(Project, pk=pk)
 
@@ -167,7 +168,7 @@ def project_dataset_create(request, pk, flag):
         })
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def project_dataset_add(request, pk):
     project = get_object_or_404(Project, pk=pk)
     if request.method == 'GET':
@@ -193,7 +194,7 @@ def project_dataset_add(request, pk):
         })
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def project_dataset_choose_type(request, pk):
     """
     View to choose dataset type to create
@@ -207,7 +208,7 @@ def project_dataset_choose_type(request, pk):
 # CONTRACTS METHODS
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def project_contract_create(request, pk):
     project = get_object_or_404(Project, pk=pk)
     # get the correct form from the flag selected
@@ -240,7 +241,7 @@ def project_contract_create(request, pk):
         })
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def project_contract_remove(request, pk, cid):
     contract = get_object_or_404(Contract, pk=cid)
     contract.project = None

--- a/web/views/publication.py
+++ b/web/views/publication.py
@@ -10,6 +10,7 @@ from core.forms import PublicationForm, PickPublicationForm
 from core.models import Project
 from core.models import Publication
 from core.permissions import permission_required
+from core.constants import Permissions
 
 
 class PublicationCreateView(CreateView):
@@ -49,14 +50,14 @@ class PublicationEditView(UpdateView):
 
 
 @require_http_methods(["DELETE"])
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def remove_publication_from_project(request, pk, publication_id):
     project = get_object_or_404(Project, pk=pk)
     project.publications.remove(publication_id)
     return HttpResponse("Publication removed from project.")
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def pick_publication_for_project(request, pk):
     if request.method == 'POST':
         form = PickPublicationForm(request.POST)
@@ -77,7 +78,7 @@ def pick_publication_for_project(request, pk):
     return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path()})
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def add_publication_to_project(request, pk):
     if request.method == 'POST':
         form = PublicationForm(request.POST)

--- a/web/views/share.py
+++ b/web/views/share.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404 , redirect, render
 
 from core.forms.share import ShareForm, shareFormFactory, ShareFormEdit
 from core.models import Share, Dataset, Partner
+from core.constants import Permissions
 from core.permissions import permission_required
 from web.views.utils import AjaxViewMixin
 from core.utils import DaisyLogger
@@ -15,7 +16,7 @@ from core.utils import DaisyLogger
 log = DaisyLogger(__name__)
 
 
-@permission_required('EDIT', (Dataset, 'pk', 'dataset_pk'))
+@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def edit_share(request, pk, dataset_pk):
     # log.debug('editing share', post=request.POST)
     share = get_object_or_404(Share, pk=pk)
@@ -79,7 +80,7 @@ class ShareCreateView(CreateView, AjaxViewMixin):
 
 
 @require_http_methods(["DELETE"])
-@permission_required('EDIT', (Dataset, 'pk', 'dataset_pk'))
+@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def remove_share(request, dataset_pk, share_pk):
     share = get_object_or_404(Share, pk=share_pk)
     dataset = get_object_or_404(Dataset, pk=dataset_pk)

--- a/web/views/storage_locations.py
+++ b/web/views/storage_locations.py
@@ -10,13 +10,14 @@ from core.forms.storage_location import StorageLocationForm, StorageLocationEdit
 from core.models import Dataset
 from core.models.storage_location import DataLocation
 from core.permissions import permission_required
+from core.constants import Permissions
 from web.views.utils import AjaxViewMixin
 from core.utils import DaisyLogger
 
 
 log = DaisyLogger(__name__)
 
-@permission_required('EDIT', (Dataset, 'pk', 'dataset_pk'))
+@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def edit_storagelocation(request, pk, dataset_pk):
     loc = get_object_or_404(DataLocation, pk=pk)
     if request.method == 'POST':

--- a/web/views/storage_locations.py
+++ b/web/views/storage_locations.py
@@ -73,7 +73,7 @@ class StorageLocationCreateView(CreateView, AjaxViewMixin):
         return reverse_lazy('dataset', kwargs={'pk': self.dataset.pk})
 
 @require_http_methods(["DELETE"])
-@permission_required('EDIT', (Dataset, 'pk', 'dataset_pk'))
+@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def remove_storagelocation(request, dataset_pk, storagelocation_pk):
     dataset = get_object_or_404(Dataset, pk=dataset_pk)
     datalocation = get_object_or_404(DataLocation, pk=storagelocation_pk)

--- a/web/views/users.py
+++ b/web/views/users.py
@@ -6,10 +6,11 @@ from django.views.decorators.http import require_http_methods
 from core.forms.user import PickUserForm
 from core.models import Project
 from core.models import User
+from core.constants import Permissions
 from core.permissions import permission_required
 
 
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def add_personnel_to_project(request, pk):
     if request.method == 'POST':
         form = PickUserForm(request.POST)
@@ -34,7 +35,7 @@ def add_personnel_to_project(request, pk):
     return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path()})
 
 @require_http_methods(["DELETE"])
-@permission_required('EDIT', (Project, 'pk', 'pk'))
+@permission_required(Permissions.EDIT, (Project, 'pk', 'pk'))
 def remove_personnel_from_project(request, pk, user_id):
     project = get_object_or_404(Project, pk=pk)
     project.company_personnel.remove(user_id)


### PR DESCRIPTION
@pinarpink & @neoflex 
Found it. 

In the permission methods, ones need to use the constants like `Permissions.EDIT` instead of the string `EDIT`.

I found 21 more occurences where it needs to be fixed, like `remove_contact_from_project` or `pick_contact_for_project`....