### PR TITLE
adding backup restore steps

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -608,15 +608,17 @@ systemctl start celery_beat
 ```
 # Restoring backup of Daisy
 First, make sure you have successfully backed up your Daisy deployment - see first section of chapter Updating Daisy.
+Your backup .tar file should contain both the dump of Postgresql database and everything from `/home/daisy` directory.
 
+As root user, stop services:
 ```bash
 systemctl stop gunicorn
 systemctl stop celery_worker
 systemctl stop celery_beat
 ```
 
-Wipe out broken/unwanted version of Daisy by deleting all files in daisy user home directory and dropping the database:
-
+Wipe out broken/unwanted version of Daisy by deleting all files in daisy user home directory and dropping the database:  
+**IMPORTANT NOTE**: Be sure that your backup .tar file is stored somewhere else!
 ```
 sudo mv /home/daisy/daisy_dump.sql /tmp/
 sudo rm -rf /home/daisy/*

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -620,20 +620,19 @@ systemctl stop celery_beat
 Wipe out broken/unwanted version of Daisy by deleting all files in daisy user home directory and dropping the database:  
 **IMPORTANT NOTE**: Be sure that your backup .tar file is stored somewhere else!
 ```
-sudo mv /home/daisy/daisy_dump.sql /tmp/
-sudo rm -rf /home/daisy/*
-sudo su -c 'dropdb daisy' - postgres
+rm -rf /home/daisy/*
+su -c 'dropdb daisy' - postgres
 ```
-Restore files from tar ball:
 
+Restore files from tar ball:
 ```
-sudo su -c 'tar -xvf /tmp/daisy.tar --directory /' - daisy
+su -c 'tar -xvf <PATH-TO-BACKUP-FOLDER>/daisy.tar --directory /' - daisy
 ```
 
 Following steps assume that the Postgresql10 is installed, pg_hba.conf file is updated and database user *daisy* exists (please see the postgresql deployment instructions for more information).
 Create the database and grant privileges:
 ```
-sudo su - postgres
+su - postgres
 createdb daisy
 psql -d daisy -p 5432 -c "grant all privileges on database daisy to daisy"
 exit
@@ -641,12 +640,12 @@ exit
 
 Restore the database as daisy user: 
 ```
-sudo su -c 'psql -d daisy -U daisy -p 5432 < /tmp/daisy_dump.sql' - daisy
+su -c 'psql -d daisy -U daisy -p 5432 < /home/daisy/daisy_dump.sql' - daisy
 ```
 
 Start services: 
 ```
-sudo systemctl start gunicorn
-sudo systemctl start celery_worker
-sudo systemctl start celery_beat 
+systemctl start gunicorn
+systemctl start celery_worker
+systemctl start celery_beat 
 ```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -609,13 +609,19 @@ systemctl start celery_beat
 # Restoring backup of Daisy
 First, make sure you have successfully backed up your Daisy deployment - see first section of chapter Updating Daisy.
 
+```bash
+systemctl stop gunicorn
+systemctl stop celery_worker
+systemctl stop celery_beat
+```
+
 Wipe out broken/unwanted version of Daisy by deleting all files in daisy user home directory and dropping the database:
+
 ```
 sudo mv /home/daisy/daisy_dump.sql /tmp/
 sudo rm -rf /home/daisy/*
 sudo su -c 'dropdb daisy' - postgres
 ```
-
 Restore files from tar ball:
 
 ```
@@ -636,7 +642,7 @@ Restore the database as daisy user:
 sudo su -c 'psql -d daisy -U daisy -p 5432 < /tmp/daisy_dump.sql' - daisy
 ```
 
-Start services 
+Start services: 
 ```
 sudo systemctl start gunicorn
 sudo systemctl start celery_worker

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -527,8 +527,8 @@ As root user:
 systemctl stop gunicorn
 systemctl stop celery_worker
 systemctl stop celery_beat 
-tar -cvf /tmp/daisy.tar /home/daisy 
 su -c 'PGPASSWORD="<PASSWORD_OF_POSTGRES_USER>" pg_dump daisy --port=5432 --username=daisy --clean > daisy_dump.sql' - daisy 
+tar -cvf /tmp/daisy.tar /home/daisy 
 ```
 
 Once you have have created the tar ball of the application directory and the postgres dump, then you may proceed to update.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -606,3 +606,39 @@ systemctl start gunicorn
 systemctl start celery_worker
 systemctl start celery_beat 
 ```
+# Restoring backup of Daisy
+First, make sure you have successfully backed up your Daisy deployment - see first section of chapter Updating Daisy.
+
+Wipe out broken/unwanted version of Daisy by deleting all files in daisy user home directory and dropping the database:
+```
+sudo mv /home/daisy/daisy_dump.sql /tmp/
+sudo rm -rf /home/daisy/*
+sudo su -c 'dropdb daisy' - postgres
+```
+
+Restore files from tar ball:
+
+```
+sudo su -c 'tar -xvf /tmp/daisy.tar --directory /' - daisy
+```
+
+Following steps assume that the Postgresql10 is installed, pg_hba.conf file is updated and database user *daisy* exists (please see the postgresql deployment instructions for more information).
+Create the database and grant privileges:
+```
+sudo su - postgres
+createdb daisy
+psql -d daisy -p 5432 -c "grant all privileges on database daisy to daisy"
+exit
+```
+
+Restore the database as daisy user: 
+```
+sudo su -c 'psql -d daisy -U daisy -p 5432 < /tmp/daisy_dump.sql' - daisy
+```
+
+Start services 
+```
+sudo systemctl start gunicorn
+sudo systemctl start celery_worker
+sudo systemctl start celery_beat 
+```


### PR DESCRIPTION
pg_dump is called with --clean flag but this may cause errors when some tables are missing. That is why I included absolute drop of the database - starting with a clean sheet is easier.
Backup was done by first tar-ing the home directory and then exporting dump into the directory. This should be changed so the .tar archive contains also the database dump, right?

