### PR TITLE
feat: added version number to html

### DIFF
--- a/elixir_daisy/settings.py
+++ b/elixir_daisy/settings.py
@@ -85,6 +85,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'web.views.context_processors.daisy_version'
             ],
         },
     },

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -5,6 +5,7 @@
     <div class="row mt-4">
         <div class="jumbotron col">
             <h1 class="display-4">DAta Information SYstem</h1>
+            <span class="badge badge-pill badge-light">Version {{ app_version }}</span>
         </div>
     </div>
     <div class="row mt-4">

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -6,6 +6,7 @@
     <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="version" content="{{ app_version }}">
 
     <!-- Material Design for Bootstrap fonts and icons -->
     <link rel="stylesheet" href="{% static 'css/gfonts.css' %}">

--- a/web/views/about.py
+++ b/web/views/about.py
@@ -1,15 +1,9 @@
 from django.shortcuts import render
-import pkg_resources
 from stronghold.decorators import public
 
 @public
 def about(request):
-
-    context = {
-        "app_version": pkg_resources.require("elixir-daisy")[0].version
-
-    }
     return render(
         request,
-        'about.html', context
+        'about.html'
     )

--- a/web/views/context_processors.py
+++ b/web/views/context_processors.py
@@ -1,0 +1,13 @@
+import pkg_resources
+
+def daisy_version(request):
+    daisy_packages = pkg_resources.require("elixir-daisy")
+
+    if len(daisy_packages) == 0:
+        the_version = "undefined"
+    else:
+        the_version = daisy_packages[0].version
+
+    return {
+        "app_version": the_version
+    }


### PR DESCRIPTION
What has been done?

- added place for context processors (web/views/context_processors)
- refactored getting version number from view (about) to context processor; now it is available in all the templates under `{{ app_version }}`
- meta tag with version inside every page
- badge with version number on index (dashboard) page
