### PR TITLE
chore: added dockerignore, splitted Dockerfile to enable layers caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,179 @@
+.git
+.github
+
+*.sqlite3
+*.iml
+elixir_daisy/settings_local.py
+static/css/*
+web/static/vendor/node_modules/*
+
+
+
+/log/*.log
+/log/*.log*
+/documents
+/web/static/css/daisy.min.css
+/web/static/css/daisy.css
+
+
+# The rest was created by https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+/dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.out
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Visual studio code
+.vscode
+
+# End of https://www.gitignore.io/api/python
+
+# Created by https://www.gitignore.io/api/intellij
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea
+.DS_Store
+
+# CMake
+cmake-build-debug/
+
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+
+# End of https://www.gitignore.io/api/intellij

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ RUN mkdir -p /code/log /static \
     && apt-get install -yq libsasl2-dev python-dev libldap2-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /code
-ADD . /code/
-#RUN pip install -e ".[dev]" &&  pip install coverage pytest
+
+# Copy the list of Python dependencies
+COPY ./setup.py /code/.
+# Try to install as many Python dependencies as possible...
+RUN pip install -e . 2>/dev/null || true
+# ... so that next time the project changes, the previous steps will be cached...
+COPY . /code/
+# ... and this will be blazing fast
 RUN pip install -e .


### PR DESCRIPTION
It does not affect traditional (non-docker) deployments, but optimizes Docker-based deployments.
What has been changed?

1. Added .dockerignore file. It results in Docker ignoring the specified files on building of the container.
For more details why it's important, see [this short article](https://codefresh.io/docker-tutorial/not-ignore-dockerignore-2/)
2. Splitted copying files into the container into two steps, which result in 1-6x speedup in consequent container build time (if the container was built previously on the same machine, it will use the cached results from previous build, unless you change setup.py file)