### PR TITLE
feat: increase contrast of arrows inside calendar

### DIFF
--- a/web/static/css/daisy.scss
+++ b/web/static/css/daisy.scss
@@ -385,7 +385,8 @@ body {
   }
 }
 
-
-
-
-
+/* Making bootstrap-material-datetimepicker's arrows more visible */
+.dtp .p10 > a > i {
+  color: #d9d9d9;
+  font-weight: bolder;
+}


### PR DESCRIPTION
Before:
<img width="310" alt="Screenshot 2020-04-20 at 11 16 51" src="https://user-images.githubusercontent.com/32834948/79735357-71be0400-82f8-11ea-8f9d-7d6e643965f6.png">

After:
<img width="334" alt="Screenshot 2020-04-20 at 10 59 39" src="https://user-images.githubusercontent.com/32834948/79735223-38859400-82f8-11ea-83c7-5e61a137a264.png">

Might require `docker-compose down && docker volume rm daisy_statics` in order to work under docker.

