### PR TITLE
fix: corrected link to the documentation

### DIFF
--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -15,7 +15,7 @@
                 <dt>Version</dt>
                 <dd>{{ app_version }}</dd>
                 <dt>User guide</dt>
-                <dd><a href="https://howto.lcsb.uni.lu/?daisy">https://howto.lcsb.uni.lu/?daisy</a></dd>
+                <dd><a href="https://elixir.pages.uni.lu/daisy-doc/">https://elixir.pages.uni.lu/daisy-doc/</a></dd>
                 <dt>Bug reporting</dt>
                 <dd><a href="https://github.com/elixir-luxembourg/daisy/issues">https://github.com/elixir-luxembourg/daisy/issues</a>
                 </dd>


### PR DESCRIPTION
The link will point to https://elixir.pages.uni.lu/daisy-doc/