### PR TITLE
closes: 25 compact editor forms

### DIFF
--- a/core/forms/access.py
+++ b/core/forms/access.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm, DateInput, ChoiceField
+from django.forms import ModelForm, DateInput, ChoiceField, Textarea
 
 from core.models import Access, DataLocation
 
@@ -11,7 +11,9 @@ class AccessForm(ModelForm):
         widgets = {
             # Date pickers
             'granted_on': DateInput(attrs={'class': 'datepicker'}),
-            'grant_expires_on': DateInput(attrs={'class': 'datepicker'})
+            'grant_expires_on': DateInput(attrs={'class': 'datepicker'}),
+            # Textareas
+            'access_notes': Textarea(attrs={'rows': 3, 'cols': 40}),
         }
 
     def __init__(self, *args, **kwargs):
@@ -40,7 +42,9 @@ class AccessEditForm(ModelForm):
         widgets = {
             # Date pickers
             'granted_on': DateInput(attrs={'class': 'datepicker'}),
-            'grant_expires_on': DateInput(attrs={'class': 'datepicker'})
+            'grant_expires_on': DateInput(attrs={'class': 'datepicker'}),
+            # Textareas
+            'access_notes': Textarea(attrs={'rows': 3, 'cols': 40}),
         }
 
     field_order = [
@@ -56,4 +60,3 @@ class AccessEditForm(ModelForm):
         # we don't allow editing dataset
         self.fields.pop('dataset')
         self.fields['defined_on_locations'].choices = [(d.id, d) for d in kwargs['instance'].dataset.data_locations.all()]
-

--- a/core/forms/access.py
+++ b/core/forms/access.py
@@ -13,7 +13,7 @@ class AccessForm(ModelForm):
             'granted_on': DateInput(attrs={'class': 'datepicker'}),
             'grant_expires_on': DateInput(attrs={'class': 'datepicker'}),
             # Textareas
-            'access_notes': Textarea(attrs={'rows': 3, 'cols': 40}),
+            'access_notes': Textarea(attrs={'rows': 2, 'cols': 40}),
         }
 
     def __init__(self, *args, **kwargs):
@@ -44,7 +44,7 @@ class AccessEditForm(ModelForm):
             'granted_on': DateInput(attrs={'class': 'datepicker'}),
             'grant_expires_on': DateInput(attrs={'class': 'datepicker'}),
             # Textareas
-            'access_notes': Textarea(attrs={'rows': 3, 'cols': 40}),
+            'access_notes': Textarea(attrs={'rows': 2, 'cols': 40}),
         }
 
     field_order = [

--- a/core/forms/cohort.py
+++ b/core/forms/cohort.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm
+from django.forms import ModelForm, Textarea
 
 from core.forms.input import SelectWithModal
 from core.models import Cohort
@@ -8,6 +8,9 @@ class CohortForm(ModelForm):
     class Meta:
         model = Cohort
         fields = '__all__'
+        widgets = {
+            'comments': Textarea(attrs={'rows': 3, 'cols': 40}),
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/core/forms/cohort.py
+++ b/core/forms/cohort.py
@@ -9,7 +9,7 @@ class CohortForm(ModelForm):
         model = Cohort
         fields = '__all__'
         widgets = {
-            'comments': Textarea(attrs={'rows': 3, 'cols': 40}),
+            'comments': Textarea(attrs={'rows': 2, 'cols': 40}),
         }
 
     def __init__(self, *args, **kwargs):

--- a/core/forms/contract.py
+++ b/core/forms/contract.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.forms import ModelForm, ModelChoiceField
+from django.forms import ModelForm, ModelChoiceField, Textarea
 from django.utils.text import slugify
 
 from core.forms.input import SelectWithModal
@@ -11,6 +11,9 @@ class ContractForm(ModelForm):
         model = Contract
         fields = '__all__'
         exclude = ['partners_roles']
+        widgets = {
+            'comments': Textarea(attrs={'rows': 3, 'cols': 40}),
+        }
 
     def __init__(self, *args, **kwargs):
         kwargs['label_suffix'] = ""

--- a/core/forms/contract.py
+++ b/core/forms/contract.py
@@ -12,7 +12,7 @@ class ContractForm(ModelForm):
         fields = '__all__'
         exclude = ['partners_roles']
         widgets = {
-            'comments': Textarea(attrs={'rows': 3, 'cols': 40}),
+            'comments': Textarea(attrs={'rows': 2, 'cols': 40}),
         }
 
     def __init__(self, *args, **kwargs):

--- a/core/forms/dataset.py
+++ b/core/forms/dataset.py
@@ -10,7 +10,7 @@ class DatasetForm(forms.ModelForm):
         model = Dataset
         fields = ['local_custodians', 'title', 'comments']
         widgets = {
-            'comments': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
+            'comments': forms.Textarea(attrs={'rows': 2, 'cols': 40}),
         }
 
 

--- a/core/forms/dataset.py
+++ b/core/forms/dataset.py
@@ -9,6 +9,10 @@ class DatasetForm(forms.ModelForm):
     class Meta:
         model = Dataset
         fields = ['local_custodians', 'title', 'comments']
+        widgets = {
+            'comments': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
+        }
+
 
     def __init__(self, *args, **kwargs):
         dataset = None
@@ -70,7 +74,7 @@ class DatasetForm(forms.ModelForm):
 class DatasetFormEdit(DatasetForm):
 
     class Meta(DatasetForm.Meta):
-        fields = DatasetForm.Meta.fields +['other_external_id', 'sensitivity']
+        fields = DatasetForm.Meta.fields + ['other_external_id', 'sensitivity']
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/core/forms/document.py
+++ b/core/forms/document.py
@@ -1,7 +1,8 @@
 from django import forms
+from django.forms import DateInput, Textarea
+
 from core.models import Document
 from core.forms.input import CustomClearableFileInput
-from django.forms import DateInput
 
 
 class DocumentForm(forms.ModelForm):
@@ -13,10 +14,9 @@ class DocumentForm(forms.ModelForm):
             'content': CustomClearableFileInput,
             'content_type': forms.HiddenInput(),
             'object_id': forms.HiddenInput(),
-            'expiry_date': DateInput(attrs={'class': 'datepicker'})
+            'expiry_date': DateInput(attrs={'class': 'datepicker'}),
+            'content_notes': Textarea(attrs={'rows': 3, 'cols': 40}),
         }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-

--- a/core/forms/document.py
+++ b/core/forms/document.py
@@ -15,7 +15,7 @@ class DocumentForm(forms.ModelForm):
             'content_type': forms.HiddenInput(),
             'object_id': forms.HiddenInput(),
             'expiry_date': DateInput(attrs={'class': 'datepicker'}),
-            'content_notes': Textarea(attrs={'rows': 3, 'cols': 40}),
+            'content_notes': Textarea(attrs={'rows': 2, 'cols': 40}),
         }
 
     def __init__(self, *args, **kwargs):

--- a/core/forms/project.py
+++ b/core/forms/project.py
@@ -14,6 +14,12 @@ class ProjectForm(ModelForm):
             # Date pickers
             'start_date': DateInput(attrs={'class': 'datepicker'}),
             'end_date': DateInput(attrs={'class': 'datepicker'}),
+            # Smaller text-areas
+            'description': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
+            'cner_notes': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
+            'erp_notes': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
+            'comments': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
+            'dpia': forms.Textarea(attrs={'rows': 3, 'cols': 40})
         }
         exclude = ['publications', 'contacts']
 
@@ -129,5 +135,3 @@ class DatasetSelection(forms.Form):
         heading_help = 'Select the the dataset the project uses.'
 
     dataset = forms.ModelChoiceField(queryset=Dataset.objects.all(), help_text='Select the dataset.')
-
-

--- a/core/forms/project.py
+++ b/core/forms/project.py
@@ -15,11 +15,11 @@ class ProjectForm(ModelForm):
             'start_date': DateInput(attrs={'class': 'datepicker'}),
             'end_date': DateInput(attrs={'class': 'datepicker'}),
             # Smaller text-areas
-            'description': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
-            'cner_notes': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
-            'erp_notes': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
-            'comments': forms.Textarea(attrs={'rows': 3, 'cols': 40}),
-            'dpia': forms.Textarea(attrs={'rows': 3, 'cols': 40})
+            'description': forms.Textarea(attrs={'rows': 2, 'cols': 40}),
+            'cner_notes': forms.Textarea(attrs={'rows': 2, 'cols': 40}),
+            'erp_notes': forms.Textarea(attrs={'rows': 2, 'cols': 40}),
+            'comments': forms.Textarea(attrs={'rows': 2, 'cols': 40}),
+            'dpia': forms.Textarea(attrs={'rows': 2, 'cols': 40})
         }
         exclude = ['publications', 'contacts']
 

--- a/core/forms/project.py
+++ b/core/forms/project.py
@@ -15,7 +15,7 @@ class ProjectForm(ModelForm):
             'start_date': DateInput(attrs={'class': 'datepicker'}),
             'end_date': DateInput(attrs={'class': 'datepicker'}),
             # Smaller text-areas
-            'description': forms.Textarea(attrs={'rows': 2, 'cols': 40}),
+            'description': forms.Textarea(attrs={'rows': 6, 'cols': 40}),
             'cner_notes': forms.Textarea(attrs={'rows': 2, 'cols': 40}),
             'erp_notes': forms.Textarea(attrs={'rows': 2, 'cols': 40}),
             'comments': forms.Textarea(attrs={'rows': 2, 'cols': 40}),

--- a/core/forms/share.py
+++ b/core/forms/share.py
@@ -13,7 +13,7 @@ class ShareForm(ModelForm):
             # Date pickers
             'granted_on': DateInput(attrs={'class': 'datepicker'}),
             'grant_expires_on': DateInput(attrs={'class': 'datepicker'}),
-            'share_notes': Textarea(attrs={'rows': 3, 'cols': 40}),
+            'share_notes': Textarea(attrs={'rows': 2, 'cols': 40}),
         }
         help_texts = {
             'contract': ''

--- a/core/forms/share.py
+++ b/core/forms/share.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.forms import ModelForm, DateInput
+from django.forms import ModelForm, DateInput, Textarea
 
 from core.models import Share, Partner, Contract, PartnerRole
 
@@ -12,7 +12,8 @@ class ShareForm(ModelForm):
         widgets = {
             # Date pickers
             'granted_on': DateInput(attrs={'class': 'datepicker'}),
-            'grant_expires_on': DateInput(attrs={'class': 'datepicker'})
+            'grant_expires_on': DateInput(attrs={'class': 'datepicker'}),
+            'share_notes': Textarea(attrs={'rows': 3, 'cols': 40}),
         }
         help_texts = {
             'contract': ''

--- a/web/static/css/daisy.scss
+++ b/web/static/css/daisy.scss
@@ -390,3 +390,8 @@ body {
   color: #d9d9d9;
   font-weight: bolder;
 }
+
+/* Reduce padding in forms */
+form.col-md-12.nice-selects > .form-group.bmd-form-group {
+  padding-top: 0.75rem;
+}

--- a/web/templates/_includes/field.html
+++ b/web/templates/_includes/field.html
@@ -1,7 +1,6 @@
 {% load widget_tweaks %}
 
-<div class="form-group {% if field.field.required %}required{% endif %}">
-
+<div class="form-group {% if field.field.required %}required{% endif %} col-md-5 mr-3">
     {% if field.field.widget.input_type == 'checkbox' %}
         {% include '_includes/checkbox.html' %}
     {% elif field.field.widget.input_type == 'radio' %}

--- a/web/templates/_includes/field.html
+++ b/web/templates/_includes/field.html
@@ -1,6 +1,6 @@
 {% load widget_tweaks %}
 
-<div class="form-group {% if field.field.required %}required{% endif %} col-md-5 mr-3">
+<div class="form-group {% if field.field.required %}required{% endif %}">
     {% if field.field.widget.input_type == 'checkbox' %}
         {% include '_includes/checkbox.html' %}
     {% elif field.field.widget.input_type == 'radio' %}

--- a/web/templates/_includes/forms.html
+++ b/web/templates/_includes/forms.html
@@ -8,16 +8,21 @@
         </button>
     </div>
 {% endfor %}
-<form {% if form_id %}id="{{ form_id }}"{% endif %}class="form {% if half %}col-md-6{% else %}col-md-12{% endif %} nice-selects {{ form_class }}"
-      {% if enctype %}enctype="{{ enctype }}"{% endif %} method="post"
-      {% if submit_url %}action="{{ submit_url }}"{% endif %}novalidate>
-    {% csrf_token %}
-    {% for hidden_field in form.hidden_fields %}
-        {{ hidden_field }}
-    {% endfor %}
-    {% for field in form.visible_fields %}
-        {% include '_includes/field.html' with field=field %}
-    {% endfor %}
+<form {% if form_id %}id="{{ form_id }}"{% endif %}
+      class="form nice-selects {{ form_class }}" method="post" novalidate
+      {% if enctype %}enctype="{{ enctype }}"{% endif %}
+      {% if submit_url %}action="{{ submit_url }}"{% endif %}>
+    <div class="row ml-1 mr-1">
+      {% csrf_token %}
+
+      {% for hidden_field in form.hidden_fields %}
+          {{ hidden_field }}
+      {% endfor %}
+
+      {% for field in form.visible_fields %}
+          {% include '_includes/field.html' with field=field %}
+      {% endfor %}
+    </div>
     {% if not hide_submit %}
         {% if wizard and wizard_url_name %}
             <div class="row">
@@ -33,10 +38,11 @@
         {% else %}
             <button type="submit"
                     {% if submit_disabled %}disabled="disabled"{% endif %}
-                    class="btn btn-primary btn-raised">{{ submit_label | default:"Submit" }}</button>
+                    class="btn btn-primary btn-raised btn-block">{{ submit_label | default:"Submit" }}</button>
         {% endif %}
     {% endif %}
     {% if cancel_button %}
-        <a href="{{ cancel_button }}" class="btn btn-secondary btn-raised float-right">Cancel</a>
+        <a href="{{ cancel_button }}" class="btn btn-secondary btn-block btn-raised float-right">Cancel</a>
     {% endif %}
+
 </form>

--- a/web/templates/_includes/forms.html
+++ b/web/templates/_includes/forms.html
@@ -8,11 +8,13 @@
         </button>
     </div>
 {% endfor %}
+
 <form {% if form_id %}id="{{ form_id }}"{% endif %}
-      class="form nice-selects {{ form_class }}" method="post" novalidate
+      class="form {% if half %}col-md-6{% else %}col-md-12{% endif %} nice-selects {{ form_class }}"
+      method="post" novalidate
       {% if enctype %}enctype="{{ enctype }}"{% endif %}
       {% if submit_url %}action="{{ submit_url }}"{% endif %}>
-    <div class="row ml-1 mr-1">
+      
       {% csrf_token %}
 
       {% for hidden_field in form.hidden_fields %}
@@ -22,7 +24,7 @@
       {% for field in form.visible_fields %}
           {% include '_includes/field.html' with field=field %}
       {% endfor %}
-    </div>
+
     {% if not hide_submit %}
         {% if wizard and wizard_url_name %}
             <div class="row">

--- a/web/templates/_includes/search_form.html
+++ b/web/templates/_includes/search_form.html
@@ -2,7 +2,7 @@
     <h1 class="display-4">Search {{title}}</h1>
 </div>
 <div class="row">
-    <div class="col">
+    <div class="col-lg-12 col-xl-6">
         <form class="form-inline" method="get" action="{% url url %}">
             <div class="form-group">
                 <label for="query" class="bmd-label-floating">

--- a/web/templates/_includes/search_form.html
+++ b/web/templates/_includes/search_form.html
@@ -1,27 +1,36 @@
 <div class="row">
-    <h1 class="display-4">Search {{title}}</h1>
+    <h1 class="display-4">
+        Browse {{title}}
+    </h1>
 </div>
 <div class="row">
-    <div class="col-lg-12 col-xl-6">
-        <form class="form-inline" method="get" action="{% url url %}">
-            <div class="form-group">
-                <label for="query" class="bmd-label-floating">
-                    &nbsp;<i class="material-icons">search</i> Query
-                </label>
-                <input type='text' class="form-control border border-top-0 bg-white" name='query' value='{{ query }}'/>
+    <div class="col-md-12 col-lg-11">
+        <div class="row">
+            <div class="col-xl-5 col-lg-12">
+                <form class="form-inline" method="get" action="{% url url %}">
+                    <div class="form-group">
+                        <label for="query" class="bmd-label-floating">
+                            &nbsp;<i class="material-icons">search</i> Query
+                        </label>
+                        <input type='text' class="form-control border border-top-0 bg-white" name='query' value='{{ query }}'/>
+                    </div>
+                    <span class="form-group bmd-form-group"> <!-- needed to match padding for floating labels -->
+                        <button type="submit" class="btn btn-primary">Search</button>
+                    </span>
+                </form>
             </div>
-            <span class="form-group bmd-form-group"> <!-- needed to match padding for floating labels -->
-            <button type="submit" class="btn btn-primary">Search</button>
-        </span>
-        </form>
-    </div>
-    {% if order_by_fields %}
-    <div class="col mr-auto">
-        <div class="btn-group" role="group">
-            {% for field in order_by_fields %}
-                {% orderbylink search_url field %}
-            {% endfor %}
+    
+            <div class="col-xl-7 col-lg-12 mt-4 mb-2">
+                {% if order_by_fields %}
+                <div class="mr-auto float-right">
+                    <div class="btn-group-sm" role="group">
+                        {% for field in order_by_fields %}
+                            {% orderbylink search_url field %}
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+            </div>
         </div>
     </div>
-    {% endif %}
 </div>

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -8,7 +8,7 @@
         </div>
     </div>
 
-    <div class="card">
+    <div class="card row">
         <div class="card-body">
             <div class="col">
                 <dd>

--- a/web/templates/cohorts/cohort_form.html
+++ b/web/templates/cohorts/cohort_form.html
@@ -3,7 +3,7 @@
 {% block title %}Cohort - Add{% endblock %}
 
 {% block content %}
-    <div class="jumbotron mt-4">
+    <div class="jumbotron mt-4 {% block jumbotron_class %}{% endblock %}">
         <h1 class="display-4">{% block content_title %}Cohort{% endblock %}</h1>
     </div>
     <div class="card">

--- a/web/templates/cohorts/cohort_form_edit.html
+++ b/web/templates/cohorts/cohort_form_edit.html
@@ -1,5 +1,6 @@
 {% extends 'cohorts/cohort_form.html' %}
 
-{% block title %}Cohort - Edit{% endblock %}
-{% block card_title %}Edit cohort{% endblock %}
-{% block content_title %}Cohort "<strong>{{ cohort.title }}</strong>"{% endblock %}
+{% block title %}{% endblock %}
+{% block card_title %}Edit cohort - <strong>{{ cohort.title }}</strong>{% endblock %}
+{% block jumbotron_class %}d-none{% endblock %}
+{% block content_title %}Cohort {{ cohort.title }}{% endblock %}

--- a/web/templates/contacts/contact_form.html
+++ b/web/templates/contacts/contact_form.html
@@ -3,7 +3,7 @@
 {% block title %}Contact - Add{% endblock %}
 
 {% block content %}
-    <div class="jumbotron mt-4">
+    <div class="jumbotron mt-4 {% block jumbotron_class %}{% endblock %}">
         <h1 class="display-4">{% block content_title %}Contacts{% endblock %}</h1>
     </div>
     <div class="card">

--- a/web/templates/contacts/contact_form_edit.html
+++ b/web/templates/contacts/contact_form_edit.html
@@ -1,5 +1,6 @@
 {% extends 'contacts/contact_form.html' %}
 
-{% block title %}Contact - Edit - {{ contact.full_name }}{% endblock %}
-{% block card_title %}Edit contact{% endblock %}
+{% block title %}{% endblock %}
+{% block jumbotron_class %}d-none{% endblock %}
+{% block card_title %}Edit contact - <strong>{{ contact.full_name }}</strong>{% endblock %}
 {% block content_title %}{{ contact.full_name }}{% endblock %}

--- a/web/templates/contracts/contract_form.html
+++ b/web/templates/contracts/contract_form.html
@@ -3,7 +3,7 @@
 {% block title %}Contract - Add{% endblock %}
 
 {% block content %}
-    <div class="jumbotron mt-4">
+    <div class="jumbotron mt-4 {% block jumbotron_class %}{% endblock %}">
         <h1 class="display-4">{% block content_title %}Contracts{% endblock %}</h1>
     </div>
     <div class="card">

--- a/web/templates/contracts/contract_form_edit.html
+++ b/web/templates/contracts/contract_form_edit.html
@@ -1,5 +1,6 @@
 {% extends 'contracts/contract_form.html' %}
 
-{% block title %}Contract - Edit{% endblock %}
-{% block card_title %}Edit contract{% endblock %}
+{% block title %}{% endblock %}
+{% block jumbotron_class %}d-none{% endblock %}
+{% block card_title %}Edit - <strong>{{ contract }}</strong>{% endblock %}
 {% block content_title %}{{ contract }}{% endblock %}

--- a/web/templates/datasets/dataset.html
+++ b/web/templates/datasets/dataset.html
@@ -105,7 +105,7 @@
                 <h2 class="card-title">Data declarations</h2>
 
                 {% if dataset.data_declarations.all %}
-                    <div class="table table-responsive">
+                    <div class="table-responsive">
                     <table class="table table-striped">
                         <thead>
                         <tr>

--- a/web/templates/datasets/dataset_form.html
+++ b/web/templates/datasets/dataset_form.html
@@ -3,7 +3,7 @@
 {% block title %}Dataset - Add{% endblock %}
 
 {% block content %}
-    <div class="jumbotron mt-4">
+    <div class="jumbotron mt-4 {% block jumbotron_class %}{% endblock %}">
         <h1 class="display-4">{% block content_title %}Datasets{% endblock %}</h1>
     </div>
     <div class="card">

--- a/web/templates/datasets/dataset_form_edit.html
+++ b/web/templates/datasets/dataset_form_edit.html
@@ -1,5 +1,6 @@
 {% extends 'datasets/dataset_form.html' %}
 
-{% block title %}Dataset - Edit - {{ dataset.title }}{% endblock %}
-{% block card_title %}Edit dataset - {{ dataset.title }}{% endblock %}
+{% block title %}{% endblock %}
+{% block jumbotron_class %}d-none{% endblock %}
+{% block card_title %}Edit dataset - <strong>{{ dataset.title }}</strong>{% endblock %}
 {% block content_title %}{{ dataset.title }}{% endblock %}

--- a/web/templates/datasets/dataset_list.html
+++ b/web/templates/datasets/dataset_list.html
@@ -25,6 +25,3 @@
     {% empty %}
         <p>No results</p>
     {% endfor %}
-
-
-

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -54,7 +54,7 @@
 {% endblock %}
 <!-- Modal -->
 <div class="modal fade" id="modal" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="modalLabel"></h5>

--- a/web/templates/partners/partner_form.html
+++ b/web/templates/partners/partner_form.html
@@ -3,7 +3,7 @@
 {% block title %}Partners - Add{% endblock %}
 
 {% block content %}
-    <div class="jumbotron mt-4">
+    <div class="jumbotron mt-4 {% block jumbotron_class %}{% endblock %}">
         <h1 class="display-4">{% block content_title %}Partners{% endblock %}</h1>
     </div>
     <div class="card">

--- a/web/templates/partners/partner_form_edit.html
+++ b/web/templates/partners/partner_form_edit.html
@@ -1,5 +1,6 @@
 {% extends 'partners/partner_form.html' %}
 
-{% block title %}Partner - Edit{% endblock %}
-{% block card_title %}Edit partner{% endblock %}
-{% block content_title %}Partner "<strong>{{ partner.name }}</strong>"{% endblock %}
+{% block title %}{% endblock %}
+{% block card_title %}Edit partner - <strong>{{ partner.name }}</strong>{% endblock %}
+{% block jumbotron_class %}d-none{% endblock %}
+{% block content_title %}Partner{% endblock %}

--- a/web/templates/projects/project_form.html
+++ b/web/templates/projects/project_form.html
@@ -4,7 +4,7 @@
 {% block title %}Project - Add{% endblock %}
 
 {% block content %}
-    <div class="jumbotron mt-4">
+    <div class="jumbotron mt-4 {% block jumbotron_class %}{% endblock %}">
         <h1 class="display-4">{% block content_title %}Projects{% endblock %}</h1>
     </div>
     <div class="card">

--- a/web/templates/projects/project_form_edit.html
+++ b/web/templates/projects/project_form_edit.html
@@ -1,5 +1,6 @@
 {% extends 'projects/project_form.html' %}
 
-{% block title %}Project - Edit - {{ project.acronym }}{% endblock %}
-{% block card_title %}Edit project{% endblock %}
+{% block title %}{% endblock %}
+{% block jumbotron_class %}d-none{% endblock %}
+{% block card_title %}Edit project - <strong>{{ project.acronym }}</strong>{% endblock %}
 {% block content_title %}{{ project.acronym }}{% endblock %}

--- a/web/templates/publications/publication_form.html
+++ b/web/templates/publications/publication_form.html
@@ -3,7 +3,7 @@
 {% block title %}Publication - Add{% endblock %}
 
 {% block content %}
-    <div class="jumbotron mt-4">
+    <div class="jumbotron mt-4 {% block jumbotron_class %}{% endblock %}">
         <h1 class="display-4">{% block content_title %}Publications{% endblock %}</h1>
     </div>
     <div class="card">

--- a/web/templates/publications/publication_form_edit.html
+++ b/web/templates/publications/publication_form_edit.html
@@ -1,5 +1,6 @@
 {% extends 'publications/publication_form.html' %}
 
-{% block title %}Publication - Edit - {{ publication.citation }}{% endblock %}
+{% block title %}{% endblock %}
+{% block jumbotron_class %}d-none{% endblock %}
 {% block card_title %}Edit publication{% endblock %}
 {% block content_title %}{{ publication.citation }}{% endblock %}

--- a/web/templates/search/_items/cohorts.html
+++ b/web/templates/search/_items/cohorts.html
@@ -1,23 +1,23 @@
 {% for cohort in data.cohorts %}
     <div class="row">
-        <div class="col-md-9 mb-4 card-item card">
+        <div class="col-md-12 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
-                    {{ cohort.title }}
+                    <a href="{% url 'cohort' pk=cohort.pk %}">{{ cohort.title }}</a>
                 </h2>
                 <ul class="card-text">
-                        <li>Owners:  {% for contact in cohort.owners %}
+                        <li><strong>Owners:</strong>  {% for contact in cohort.owners %}
                             <span class="badge badge-pill badge-secondary">{{ contact }}</span>
                         {% empty %}
                             "unknown"
                         {% endfor %}</li>
-                        <li>Institutes: {% for institute in cohort.institutes %}
+                        <li><strong>Institutes:</strong> {% for institute in cohort.institutes %}
                             <span class="badge badge-pill badge-secondary">{{ institute }}</span>
                         {% empty %}
                             "unknown"
                         {% endfor %}</li>
-                        <li>Ethics Confirmation: {% if cohort.ethics_confirmation %}
-                            <i class="material-icons">
+                        <li><strong>Ethics Confirmation:</strong> {% if cohort.ethics_confirmation %}
+                            <i class="material-icons text-success">
                                 check
                             </i>
                         {% else %}
@@ -25,13 +25,10 @@
                         {% endif %}
                         </li>
                 </ul>
-                <a href="{% url 'cohort' pk=cohort.pk %}" class="btn btn-primary">Details</a>
+                <a href="{% url 'cohort' pk=cohort.pk %}" class="btn btn-secondary btn-outline">Details &raquo;</a>
             </div>
         </div>
     </div>
 {% empty %}
     <p>No results</p>
 {% endfor %}
-
-
-

--- a/web/templates/search/_items/cohorts.html
+++ b/web/templates/search/_items/cohorts.html
@@ -1,6 +1,6 @@
 {% for cohort in data.cohorts %}
     <div class="row">
-        <div class="col-md-12 mb-4 card-item card">
+        <div class="col-md-11 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
                     <a href="{% url 'cohort' pk=cohort.pk %}">{{ cohort.title }}</a>

--- a/web/templates/search/_items/contacts.html
+++ b/web/templates/search/_items/contacts.html
@@ -1,29 +1,27 @@
 {% for contact in data.contacts %}
     <div class="row">
-        <div class="col-md-9 mb-4 card-item card">
+        <div class="col-md-12 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
-                    {{ contact.first_name }} {{ contact.last_name }}
+                    <a href="{% url 'contact' pk=contact.pk %}">{{ contact.first_name }} {{ contact.last_name }}</a>
                 </h2>
                 <ul class="card-text">
-                    <li>Role: <span class="badge badge-pill badge-secondary">{{ contact.type }}</span>
+                    <li>
+                      <strong>Role:</strong> <span class="badge badge-pill badge-secondary">{{ contact.type }}</span>
                     </li>
-                    <li>Affiliation(s):
+                    <li><strong>Affiliation(s):</strong>
                         {% for partner in contact.partners %}
                             <span class="badge badge-pill badge-primary">{{ partner }}</span>
 
                         {% empty %}
-                            "-"
+                            -
                         {% endfor %}
                     </li>
                 </ul>
-                <a href="{% url 'contact' pk=contact.pk %}" class="btn btn-primary">Details</a>
+                <a href="{% url 'contact' pk=contact.pk %}" class="btn btn-secondary btn-outline">Details &raquo;</a>
             </div>
         </div>
     </div>
 {% empty %}
     <p>No results</p>
 {% endfor %}
-
-
-

--- a/web/templates/search/_items/contacts.html
+++ b/web/templates/search/_items/contacts.html
@@ -1,6 +1,6 @@
 {% for contact in data.contacts %}
     <div class="row">
-        <div class="col-md-12 mb-4 card-item card">
+        <div class="col-md-11 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
                     <a href="{% url 'contact' pk=contact.pk %}">{{ contact.first_name }} {{ contact.last_name }}</a>

--- a/web/templates/search/_items/contracts.html
+++ b/web/templates/search/_items/contracts.html
@@ -1,6 +1,6 @@
 {% for contract in data.contracts %}
     <div class="row">
-        <div class="col-md-12 mb-4 card-item card">
+        <div class="col-md-11 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
                     <a href="{% url 'contract' pk=contract.pk %}">{{ contract.partners | join:", " }}{% if contract.project %}<small> - "{{ contract.project }}"</small>{% endif %}</a>

--- a/web/templates/search/_items/contracts.html
+++ b/web/templates/search/_items/contracts.html
@@ -1,18 +1,18 @@
 {% for contract in data.contracts %}
     <div class="row">
-        <div class="col-md-9 mb-4 card-item card">
+        <div class="col-md-12 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
-			{{ contract.partners | join:", " }}{% if contract.project %}<small> - "{{ contract.project }}"</small>{% endif %}
+                    <a href="{% url 'contract' pk=contract.pk %}">{{ contract.partners | join:", " }}{% if contract.project %}<small> - "{{ contract.project }}"</small>{% endif %}</a>
                 </h2>
                 <ul class="card-text">
-                    <li>Project: <span class="badge badge-pill badge-secondary">{{ contract.project }}</span></li>
+                    <li><strong>Project:</strong> <span class="badge badge-pill badge-secondary">{{ contract.project }}</span></li>
                     {% if  contract.partners_roles %}
-                        <li>Partners roles: {{ contract.partners_roles | join:", " }}</li>
+                        <li><strong>Partners roles: </strong>{{ contract.partners_roles | join:", " }}</li>
                     {% endif %}
 
                 </ul>
-                <a href="{% url 'contract' pk=contract.pk %}" class="btn btn-primary">Details</a>
+                <a href="{% url 'contract' pk=contract.pk %}" class="btn btn-secondary btn-outline">Details &raquo;</a>
             </div>
         </div>
     </div>

--- a/web/templates/search/_items/datasets.html
+++ b/web/templates/search/_items/datasets.html
@@ -1,6 +1,6 @@
 {% for dataset in data.datasets %}
     <div class="row">
-        <div class="col-md-12 mb-4 card-item card">
+        <div class="col-md-11 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
                   <a href="{% url 'dataset' pk=dataset.pk %}">{{ dataset.title }}</a>

--- a/web/templates/search/_items/datasets.html
+++ b/web/templates/search/_items/datasets.html
@@ -1,30 +1,29 @@
 {% for dataset in data.datasets %}
     <div class="row">
-        <div class="col-md-9 mb-4 card-item card">
+        <div class="col-md-12 mb-4 card-item card">
             <div class="card-body">
-                <h2 class="card-title">{{ dataset.title }}</h2>
+                <h2 class="card-title">
+                  <a href="{% url 'dataset' pk=dataset.pk %}">{{ dataset.title }}</a>
+                </h2>
                 <ul class="card-text">
-                    <li>Published: {{ dataset.is_published | yesno }}</li>
-                    <li>Datatypes:
+                    <li><strong>Published:</strong> {{ dataset.is_published | yesno }}</li>
+                    <li><strong>Datatypes:</strong>
                         {% for datatype in dataset.data_types %}
                             <span class="badge badge-pill badge-secondary">{{ datatype }}</span>
                         {% endfor %}
                     </li>
                     {% if dataset.local_custodians %}
-                        <li>Local custodians:
+                        <li><strong>Local custodians:</strong>
                             {% for local_custodian in dataset.local_custodians %}
                                 <span class="badge badge-pill badge-primary">{{ local_custodian }}</span>
                             {% endfor %}
                         </li>
                     {% endif %}
                 </ul>
-                <a href="{% url 'dataset' pk=dataset.pk %}" class="btn btn-primary">Details</a>
+                <a href="{% url 'dataset' pk=dataset.pk %}" class="btn btn-secondary btn-outline">Details &raquo;</a>
             </div>
         </div>
     </div>
 {% empty %}
     <p>No results</p>
 {% endfor %}
-
-
-

--- a/web/templates/search/_items/partners.html
+++ b/web/templates/search/_items/partners.html
@@ -1,28 +1,27 @@
 {% for partner in data.partners %}
     <div class="row">
-        <div class="col-md-9 mb-4 card-item card">
+        <div class="col-md-12 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
-                    {{ partner.name }} {% if  partner.acronym %}({{ partner.acronym }}){% endif %}
-                    {% if  partner.is_clinical %}
-                  <i class="material-icons">local_hospital</i>
-                    {% endif %}
+                    <a href="{% url 'partner' pk=partner.pk %}">
+                      {{ partner.name }} {% if  partner.acronym %}({{ partner.acronym }}){% endif %}
+                      {% if  partner.is_clinical %}
+                        <i class="material-icons">local_hospital</i>
+                      {% endif %}
+                    </a>
                 </h2>
                 <ul class="card-text">
-                        <li>Geo-Category:
+                        <li><strong>Geo-Category:</strong>
                             <span class="badge badge-pill badge-secondary">{{ partner.geo_category  }}</span>
                         </li>
-                        <li>Sector:
+                        <li><strong>Sector:</strong>
                             <span class="badge badge-pill badge-secondary">{{ partner.sector_category }}</span>
                         </li>
                 </ul>
-                <a href="{% url 'partner' pk=partner.pk %}" class="btn btn-primary">Details</a>
+                <a href="{% url 'partner' pk=partner.pk %}" class="btn btn-secondary btn-outline">Details &raquo;</a>
             </div>
         </div>
     </div>
 {% empty %}
     <p>No results</p>
 {% endfor %}
-
-
-

--- a/web/templates/search/_items/partners.html
+++ b/web/templates/search/_items/partners.html
@@ -1,6 +1,6 @@
 {% for partner in data.partners %}
     <div class="row">
-        <div class="col-md-12 mb-4 card-item card">
+        <div class="col-md-11 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
                     <a href="{% url 'partner' pk=partner.pk %}">

--- a/web/templates/search/_items/projects.html
+++ b/web/templates/search/_items/projects.html
@@ -1,6 +1,6 @@
 {% for project in data.projects %}
     <div class="row">
-        <div class="col-md-12 mb-4 card-item card">
+        <div class="col-md-11 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
                     <a href="{% url 'project' pk=project.pk %}">{{project.acronym}}</a>

--- a/web/templates/search/_items/projects.html
+++ b/web/templates/search/_items/projects.html
@@ -1,22 +1,21 @@
 {% for project in data.projects %}
     <div class="row">
-        <div class="col-md-9 mb-4 card-item card">
+        <div class="col-md-12 mb-4 card-item card">
             <div class="card-body">
                 <h2 class="card-title">
-                    {{project.acronym}} <small>{% if project.title %}- {{project.title}}{% endif %}</small>
+                    <a href="{% url 'project' pk=project.pk %}">{{project.acronym}}</a>
+                    {% if project.title %}<small>- {{project.title}}</small>{% endif %}
                 </h2>
                 <ul class="card-text">
                     {% if  project.project_web_page %}<li>Web: {{ project.project_web_page }}</li>{% endif %}
-                    <li>Publications: <span class="badge badge-pill badge-info">{{ project.publications|length }}</span></li>
-
+                    <li>
+                      <strong>Publications:</strong> <span class="badge badge-pill badge-info">{{ project.publications|length }}</span>
+                    </li>
                 </ul>
-                <a href="{% url 'project' pk=project.pk %}" class="btn btn-primary">Details</a>
+                <a href="{% url 'project' pk=project.pk %}" class="btn btn-secondary btn-outline">Details &raquo;</a>
             </div>
         </div>
     </div>
 {% empty %}
     <p>No results</p>
 {% endfor %}
-
-
-

--- a/web/templates/search/search_page.html
+++ b/web/templates/search/search_page.html
@@ -37,4 +37,7 @@
     <a class="btn btn-primary bmd-btn-fab float-right" href="{% url add_url %}{% if reset %}?reset=true{% endif %}">
         <i class="material-icons">add</i>
     </a>
+    <a class="btn btn-secondary bmd-btn-fab d-md-none float-right" href="#sidebar-responsive-left">
+        <i class="material-icons">sort</i>
+    </a>
 {% endblock %}

--- a/web/templates/search/search_page.html
+++ b/web/templates/search/search_page.html
@@ -11,7 +11,7 @@
                 <h1 class="display-4"><i class="material-icons text-secondary">info</i> {{ title }}</h1>
             </div>
             <p>{{ help_text }}</p>
-            <p>Use the categories on the left or the search box below to locate {{ title }}.</p>
+            <p>Use the categories on the left or the search box below to locate {{ title | lower }}. In order to create add a new one, use the button at bottom-right corner .</p>
         </div>
     </div>
 

--- a/web/templates/search/search_page.html
+++ b/web/templates/search/search_page.html
@@ -4,29 +4,31 @@
 {% block containerclass %}container-fluid{% endblock %}
 
 
-
 {% block content %}
     <div class="container card bg-light text-dark">
         <div class="card-body">
             <div class="card-title">
-                <h1 class="display-4">{{ title }}</h1>
+                <h1 class="display-4"><i class="material-icons text-secondary">info</i> {{ title }}</h1>
             </div>
             <p>{{ help_text }}</p>
             <p>Use the categories on the left or the search box below to locate {{ title }}.</p>
         </div>
     </div>
 
-    <div class="row justify-content-between">
-
-        <div id="sidebar-left" class="d-flex flex-column m-5 col-3">
+    <div class="container-fluid">
+      <div class="row">
+        <div id="sidebar-left" class="d-none d-md-block mt-5 pl-5 col-xs-12 col-md-5 col-lg-5 col-xl-4 order-2">
             {% include '_includes/facets_sidebar.html' with facets=facets url=search_url %}
         </div>
-        <div class="mt-5 col-8">
+        <div id="sidebar-responsive-left" class="d-md-none mt-5 pl-5 col-12 order-6">
+            <h1 class="display-4">Filter the results</h1>
+            {% include '_includes/facets_sidebar.html' with facets=facets url=search_url %}
+        </div>
+        <div class="mt-5 pr-5 pl-5 col-xs-12 col-md-7 col-lg-7 col-xl-8 order-4">
             {% include '_includes/search_form.html' with title=title query=query url=search_url order_by_fields=order_by_fields %}
             {% include results_template_name with data=data %}
         </div>
-
-
+      </div>
     </div>
 {% endblock %}
 

--- a/web/views/context_processors.py
+++ b/web/views/context_processors.py
@@ -1,13 +1,16 @@
 import pkg_resources
 
 def daisy_version(request):
-    daisy_packages = pkg_resources.require("elixir-daisy")
+    try:
+        daisy_packages = pkg_resources.require("elixir-daisy")
 
-    if len(daisy_packages) == 0:
+        if len(daisy_packages) == 0:
+            the_version = "undefined"
+        else:
+            the_version = daisy_packages[0].version
+    except:
         the_version = "undefined"
-    else:
-        the_version = daisy_packages[0].version
-
+    
     return {
         "app_version": the_version
     }


### PR DESCRIPTION
Multiple UI tweaks. The list include:

in the editor form
- removed big block which occupies vertical space; instead only header is used
- reduced the padding-top in the edit boxes
- reduced the dimensions of textareas - down to 2 rows (much smaller in height)
- made save buttons block buttons (occupy the whole width)

in the list view:
- corrected formatting, it's clearer
- adjusted widths of the boxes on the left (longer filters do not need to be wrapped now) and right (browsed items)
- when viewport is small (mobile), the filters on the left disappear, and the filter button appears next to `Add new`
- adjusted margin of sort buttons (it matches items below)
- added help icon to help block in the top section
- lowercase in help block: `Use the categories on the left or the search box below to locate contracts` instead of `...Contracts`
- added information on how to add a new item (mentioned button on bottom-right)


<img width="1658" alt="Screenshot 2020-04-23 at 16 50 56" src="https://user-images.githubusercontent.com/32834948/80113589-cc6a9080-8582-11ea-9c5a-29448a34ecc6.png">

<img width="1664" alt="Screenshot 2020-04-23 at 16 51 20" src="https://user-images.githubusercontent.com/32834948/80113581-ca083680-8582-11ea-8a98-30a2bfeb68df.png">


Closes #25 