### PR TITLE
feat: clear button for query

### DIFF
--- a/web/static/css/daisy.scss
+++ b/web/static/css/daisy.scss
@@ -395,3 +395,8 @@ body {
 form.col-md-12.nice-selects > .form-group.bmd-form-group {
   padding-top: 0.75rem;
 }
+
+/* Clickable button that resets edit-boxes */
+i.reset-form-button {
+  cursor: pointer;
+}

--- a/web/static/js/daisy.js
+++ b/web/static/js/daisy.js
@@ -45,6 +45,17 @@ $(document).ready(function () {
 
     csrftoken = Cookies.get("csrftoken");
 
+    $(".input-group-text>i.reset-form-button").click(function(){
+        var $t = $(this);  // get the element
+        var target_id = $t.data("resets");  // get the ID of element to reset
+        var submits = $t.data("submits");  // should the form be submitted after resetting?
+        var $el = $("#" + target_id);
+        $el.val('').focus();  // reset the contents of editbox
+        if (submits) {
+            $el.form().submit();  // submit the form
+        }
+    });
+
     $('#users_table').DataTable();
 
     $('.nice-selects select').not('.dummy-select').select2({'width': '100%'});

--- a/web/templates/_includes/search_form.html
+++ b/web/templates/_includes/search_form.html
@@ -12,8 +12,17 @@
                         <label for="query" class="bmd-label-floating">
                             &nbsp;<i class="material-icons">search</i> Query
                         </label>
-                        <input type='text' class="form-control border border-top-0 bg-white" name='query' value='{{ query }}'/>
+                        <input id="query_edit" type='text' class="form-control border border-top-0 bg-white" name='query' value='{{ query }}'/>
+
+                        {% if query %}
+                        <div class="input-group-append bg-white">
+                            <span class="input-group-text">
+                                 <i class="material-icons close reset-form-button" data-resets="query_edit" data-submits="yes">close</i>
+                            </span>
+                        </div>
+                        {% endif %}
                     </div>
+                    
                     <span class="form-group bmd-form-group"> <!-- needed to match padding for floating labels -->
                         <button type="submit" class="btn btn-primary">Search</button>
                     </span>


### PR DESCRIPTION
closes #136 

Proposed behaviour - the search page is unchanged, until the user enters a query to search for.
Then, the cross button appears next to the input form.
Once clicked, it removes the contents of the input box, and reloads the page.

The reload behaviour is optional (i.e. it is controlled by the data attribute)