### PR TITLE
99 add reporting sql exporer

### DIFF
--- a/elixir_daisy/settings.py
+++ b/elixir_daisy/settings.py
@@ -57,7 +57,8 @@ INSTALLED_APPS = [
     'django_celery_results',
     'django_celery_beat',
     'celery_haystack',
-    'sequences.apps.SequencesConfig'
+    'sequences.apps.SequencesConfig',
+    'explorer'
 ]
 
 MIDDLEWARE = [
@@ -310,6 +311,11 @@ NOTIFICATIONS_DISABLED = True
 
 LOGIN_USERNAME_PLACEHOLDER = ''
 LOGIN_PASSWORD_PLACEHOLDER = ''
+
+# See: https://github.com/groveco/django-sql-explorer
+
+EXPLORER_CONNECTIONS = { 'Default': 'default' } 
+EXPLORER_DEFAULT_CONNECTION = 'default'
 
 # Import local settings to override those values based on the deployment environment
 try:

--- a/elixir_daisy/urls.py
+++ b/elixir_daisy/urls.py
@@ -38,3 +38,4 @@ if settings.DEBUG:
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ]
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    urlpatterns += url(r'^explorer/', include('explorer.urls')),

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requirements = [
     'django-haystack==2.8.1',
     'django-reversion==3.0.3',
     'django-stronghold==0.3.0',
+    'django-sql-explorer==1.1.3',
     'django-widget-tweaks==1.4.3',
     'django-countries==5.3.3',
     'gunicorn==19.9.0',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requirements = [
     'django-debug-toolbar==1.11',
     'django-enumchoicefield==1.1.0',
     'django-excel-response==2.0.4',
+    'xlsxwriter==1.2.9',
     'django-formtools==2.1',
     'django-guardian==1.5.0',
     'django-haystack==2.8.1',


### PR DESCRIPTION
branch 99-add-reporting-sql-exporer rebased on develop - I cannot force push to the branch to update -> I had to create one in my fork


I have also added `xlsxwriter==1.2.9` module - required by exporter when exporting to Excel