### PR TITLE
chore: remove staticfiles panel from DDT

### DIFF
--- a/elixir_daisy/settings.py
+++ b/elixir_daisy/settings.py
@@ -346,3 +346,20 @@ try:
     from .settings_local import *
 except ImportError as e:
     pass
+
+if DEBUG:
+    # Removing staticfiles panel from Django Debug Toolbar
+    DEBUG_TOOLBAR_PANELS = [
+        'debug_toolbar.panels.versions.VersionsPanel',
+        'debug_toolbar.panels.timer.TimerPanel',
+        'debug_toolbar.panels.settings.SettingsPanel',
+        'debug_toolbar.panels.headers.HeadersPanel',
+        'debug_toolbar.panels.request.RequestPanel',
+        'debug_toolbar.panels.sql.SQLPanel',
+        'debug_toolbar.panels.templates.TemplatesPanel',
+        'debug_toolbar.panels.cache.CachePanel',
+        'debug_toolbar.panels.signals.SignalsPanel',
+        'debug_toolbar.panels.logging.LoggingPanel',
+        'debug_toolbar.panels.redirects.RedirectsPanel',
+        'debug_toolbar.panels.profiling.ProfilingPanel',
+    ]


### PR DESCRIPTION
Removed staticfiles panel from Django Debug Toolbar. I will need to verify it myself on a VM