### PR TITLE
feat: small improvements for managing users in django-admin

### DIFF
--- a/elixir_daisy/settings.py
+++ b/elixir_daisy/settings.py
@@ -341,6 +341,9 @@ REMS_ALLOWED_IP_ADDRESSES = []  # use '*' to allow all, otherwise e.g. '127.0.0.
 # ID service
 IDSERVICE_FUNCTION = 'web.views.utils.generate_elu_accession'
 
+# Should the superuser be able to change the passwords in django-admin
+ENABLE_PASSWORD_CHANGE_IN_ADMIN = False
+
 # Import local settings to override those values based on the deployment environment
 try:
     from .settings_local import *

--- a/web/templates/navbar.html
+++ b/web/templates/navbar.html
@@ -67,6 +67,7 @@
                             {% endif %}
                             {% if request.user.is_superuser %}
                                 <a class="dropdown-item" href="{% url 'users' %}">manage users</a>
+                                <a class="dropdown-item" href="{% url 'admin:index' %}">django-admin</a>
                             {% endif %}
                             {% if request.user.source.name == 'MANUAL' %}
                                 <a class="dropdown-item" href="{% url 'users_change_password'%}">change password</a>


### PR DESCRIPTION
Small changes to Users section in django-admin:

 - added an optional flag to have the possibility to change users' passwords in settings.py
 - added a shortcut to django admin in the navbar
 - search bar works for both email and full_name in admin's User list
 - added columns with id and oidc_id in admin's User list (which makes the life a lot easier in case there's an user with empty full_name - because in such case the row was not clickable)