### PR TITLE
#371 get expiration date from rems

### DIFF
--- a/core/lcsb/rems.py
+++ b/core/lcsb/rems.py
@@ -153,7 +153,7 @@ def create_rems_entitlement(obj: Union[Access, User],
         dataset_id: str, 
         user_oidc_id: str, 
         email: str,
-        expiration_date: str) -> bool:
+        expiration_date: str = None) -> bool:
     """
     Tries to find a dataset with `elu_accession` equal to `dataset_id`.
     If it exists, it will add a new logbook entry (Access object) set to the current user/contact
@@ -181,7 +181,9 @@ def create_rems_entitlement(obj: Union[Access, User],
         system_rems_user = system_rems_user.first()
 
     if expiration_date is None:
-        entitlement_end = date.today() + timedelta(days=90)
+        entitlement_end = date.today() + timedelta(
+            days=getattr(settings, 'ACCESS_DEFAULT_EXPIRATION_DAYS', 90)
+        )
     else:
         entitlement_end = isoparse(expiration_date).date()
 

--- a/core/lcsb/rems.py
+++ b/core/lcsb/rems.py
@@ -53,9 +53,6 @@ def handle_rems_callback(request: HttpRequest) -> bool:
 
     logger.debug('REMS :: Unpacking the data received from REMS...')
     body_unicode = request.body.decode('utf-8')
-    logger.debug('REMS :: Got the following request body: {}'.format(request.body.decode("utf-8")))
-    logger.debug('REMS :: Here is the request headers: {}'.format(request.headers))
-    logger.debug('REMS :: Here is the request data: {}'.format(request.POST))
 
     try:
         request_post_data = json.loads(body_unicode)

--- a/core/lcsb/rems.py
+++ b/core/lcsb/rems.py
@@ -2,7 +2,8 @@ import json
 import logging
 import urllib3
 
-from datetime import datetime, timedelta
+from datetime import datetime, date, timedelta
+from dateutil.parser import isoparse
 from typing import Dict, Union
 
 from django.conf import settings
@@ -52,6 +53,9 @@ def handle_rems_callback(request: HttpRequest) -> bool:
 
     logger.debug('REMS :: Unpacking the data received from REMS...')
     body_unicode = request.body.decode('utf-8')
+    logger.debug('REMS :: Got the following request body: {}'.format(request.body.decode("utf-8")))
+    logger.debug('REMS :: Here is the request headers: {}'.format(request.headers))
+    logger.debug('REMS :: Here is the request data: {}'.format(request.POST))
 
     try:
         request_post_data = json.loads(body_unicode)
@@ -180,9 +184,9 @@ def create_rems_entitlement(obj: Union[Access, User],
         system_rems_user = system_rems_user.first()
 
     if expiration_date is None:
-        entitlement_end = datetime.now() + timedelta(days=90)
+        entitlement_end = date.today() + timedelta(days=90)
     else:
-        entitlement_end = datetime.strptime(expiration_date, "%Y-%M-%dT%H:%B:%S")
+        entitlement_end = isoparse(expiration_date).date()
 
     if type(obj) == User:
         new_logbook_entry = Access(

--- a/core/lcsb/rems.py
+++ b/core/lcsb/rems.py
@@ -4,7 +4,7 @@ import urllib3
 
 from datetime import datetime, date, timedelta
 from dateutil.parser import isoparse
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -153,7 +153,7 @@ def create_rems_entitlement(obj: Union[Access, User],
         dataset_id: str, 
         user_oidc_id: str, 
         email: str,
-        expiration_date: str = None) -> bool:
+        expiration_date: Optional[str] = None) -> bool:
     """
     Tries to find a dataset with `elu_accession` equal to `dataset_id`.
     If it exists, it will add a new logbook entry (Access object) set to the current user/contact

--- a/core/tests/test_lcsb.py
+++ b/core/tests/test_lcsb.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from typing import Dict, List
@@ -96,6 +98,7 @@ def test_keycloak_synchronization_config_validation():
 
 def test_add_rems_entitlements():
     elu_accession='12345678'
+    expiration_date = "2022-09-08T23:59:00.000Z"
 
     user = UserFactory(oidc_id='12345', email='example@example.org')
     user.save()
@@ -103,8 +106,9 @@ def test_add_rems_entitlements():
     dataset = DatasetFactory(title='Test', local_custodians=[user], elu_accession=elu_accession)
     dataset.save()
 
-    create_rems_entitlement(user, 'Test Application', elu_accession, user.oidc_id, user.email)
+    create_rems_entitlement(user, 'Test Application', elu_accession, user.oidc_id, user.email, expiration_date)
     user.delete()
+
 
 def test_permissions():
     user = UserFactory(oidc_id='12345')

--- a/core/tests/test_lcsb.py
+++ b/core/tests/test_lcsb.py
@@ -97,8 +97,8 @@ def test_keycloak_synchronization_config_validation():
 
 
 def test_add_rems_entitlements():
-    elu_accession='12345678'
-    expiration_date = "2022-09-08T23:59:00.000Z"
+    elu_accession = '12345678'
+    expiration_date = datetime.date.today() + datetime.timedelta(days=1)
 
     user = UserFactory(oidc_id='12345', email='example@example.org')
     user.save()

--- a/elixir_daisy/settings.py
+++ b/elixir_daisy/settings.py
@@ -340,7 +340,7 @@ IMPORT_JSON_SCHEMAS_DIR = os.path.join(BASE_DIR, 'core', 'fixtures', 'json_schem
 REMS_INTEGRATION_ENABLED = False
 REMS_SKIP_IP_CHECK = False
 REMS_ALLOWED_IP_ADDRESSES = []  # use '*' to allow all, otherwise e.g. '127.0.0.1'...
-
+ACCESS_DEFAULT_EXPIRATION_DAYS = 90
 # ID service
 IDSERVICE_FUNCTION = 'web.views.utils.generate_elu_accession'
 


### PR DESCRIPTION
On access approval in Rems, the new Access object created in daisy now includes the expiration date set in rems.

If no expiration date was set, daisy uses a default value, which is 90 days after the approval.