### PR TITLE
set log level to info for autoreload

### DIFF
--- a/elixir_daisy/settings.py
+++ b/elixir_daisy/settings.py
@@ -264,6 +264,9 @@ LOGGING = {
             'propagate': False,
             'level': LOG_LEVEL,
         },
+        'django.utils.autoreload': {
+            'level': 'INFO',
+        },
         'daisy': {
             'handlers': ['mail_admins', 'console', 'logfile'],
             'level': LOG_LEVEL,


### PR DESCRIPTION
to avoid having hundreds of lines such as:

> DEBUG File.../django/db/models/sql/compiler.py first seen with mtime XXXXXX