### PR TITLE
370 json response model edit forms

### DIFF
--- a/core/forms/share.py
+++ b/core/forms/share.py
@@ -38,9 +38,7 @@ class ShareForm(ModelForm):
     ]
 
 
-
-
-class ShareFormEdit(ShareForm):
+class ShareEditForm(ShareForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['partner'].disabled = True

--- a/web/templates/_includes/documents_table.html
+++ b/web/templates/_includes/documents_table.html
@@ -26,6 +26,10 @@
                                 <a data-toggle="modal" id="btnupdate" class="jsBtn clickable"
                                    data-target="#modal"
                                    data-modal-title="Update document"
+                                   data-post-mode="true"
+                                   {% if project %}
+                                       data-ajax-redirect-uri="{% url 'project' pk=project.id %}"
+                                   {% endif %}
                                    data-ajax-url="{% url "document_edit" pk=file.id %}"
                                    title="Update document">
                                     <i class="material-icons">edit</i>

--- a/web/templates/datasets/dataset.html
+++ b/web/templates/datasets/dataset.html
@@ -228,6 +228,8 @@
                                        id="editlegalbasis"
                                        title="Edit legal basis"
                                        data-toggle="modal"
+                                       data-post-mode="true"
+                                       data-ajax-redirect-uri="{% url 'dataset' pk=dataset.id %}"
                                        data-target="#modal"
                                        data-modal-title="Edit legal basis"
                                        data-ajax-url="{% url 'dataset_legalbasis_edit' pk=lbd.id dataset_pk=dataset.id %}">edit</i>
@@ -292,7 +294,9 @@
                                        title="Edit storage"
                                        data-toggle="modal"
                                        data-target="#modal"
+                                       data-post-mode="true"
                                        data-modal-title="Edit storage"
+                                       data-ajax-redirect-uri="{% url 'dataset' pk=dataset.id %}"
                                        data-ajax-url="{% url 'dataset_storagelocation_edit' pk=location.id dataset_pk=dataset.id %}">edit</i>
                                     <i class="red material-icons clickable" data-method="delete"
                                        data-parent-to-remove="tr"
@@ -368,8 +372,11 @@
                                        title="Edit access"
                                        data-toggle="modal"
                                        data-target="#modal"
+                                       data-post-mode="true"
                                        data-modal-title="Edit access"
-                                       data-ajax-url="{% url 'dataset_access_edit' pk=access.id dataset_pk=dataset.id %}">edit</i>
+                                       data-ajax-url="{% url 'dataset_access_edit' pk=access.id dataset_pk=dataset.id %}"
+                                       data-ajax-redirect-uri="{% url 'dataset' pk=dataset.id %}"
+                                    >edit</i>
                                     <i class="red material-icons clickable" data-method="delete"
                                        title="Delete access"
                                        data-url="{% url 'dataset_access_remove' dataset_pk=dataset.id access_pk=access.id %}">delete_forever</i>
@@ -424,7 +431,7 @@
                     {% for share in dataset.shares.all %}
                         <tr>
                             <td><p>{% for ddec in share.data_declarations.all  %}{{ ddec.title}} <br/> {% empty %}Entire dataset{% endfor %}</p></td>
-                            <td>{%if share.data_log_type  %} {{ share.data_log_type.name }} {% else %}<p class="alert-error"> missing </p>{% endif %}</td>
+                            <td>{% if share.data_log_type  %} {{ share.data_log_type.name }} {% else %}<p class="alert-error"> missing </p>{% endif %}</td>
                             <td>{{ share.partner }}</td>
                             <td>{{ share.granted_on | default:"-" }}</td>
                             <td>{{ share.share_notes  | default:"-" }}</td>
@@ -435,6 +442,8 @@
                                        title="Edit logbook entry"
                                        data-toggle="modal"
                                        data-target="#modal"
+                                       data-post-mode="true"
+                                       data-ajax-redirect-uri="{% url 'dataset' pk=dataset.id %}"
                                        data-modal-title="Edit logbook entry"
                                        data-ajax-url="{% url 'dataset_share_edit' pk=share.id dataset_pk=dataset.id %}">edit</i>
                                     <i class="red material-icons clickable"
@@ -454,5 +463,3 @@
         </div>
     </div>
 {% endblock %}
-
-

--- a/web/urls.py
+++ b/web/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from web.views import access, api, contracts, data_declarations, datasets, \
                       documents, legalbasis, notifications, permissions, \
                       profile, projects, share, storage_locations
-from web.views.access import AccessCreateView
+from web.views.access import AccessCreateView, AccessEditView
 from web.views.about import about
 from web.views.cohorts import CohortCreateView, CohortEditView, \
                               CohortDelete, CohortDetailView, cohort_list, \
@@ -86,19 +86,19 @@ web_urls = [
     # Dataset's StorageLocation methods
     path('dataset/<int:dataset_pk>/storagelocation/add/', storage_locations.StorageLocationCreateView.as_view(), name='dataset_storagelocation_add'),
     path('dataset/<int:dataset_pk>/storagelocation/remove/<int:storagelocation_pk>/', storage_locations.remove_storagelocation, name='dataset_storagelocation_remove'),
-    path('dataset/<int:dataset_pk>/storagelocation/<int:pk>/edit', storage_locations.edit_storagelocation, name="dataset_storagelocation_edit"),
+    path('dataset/<int:dataset_pk>/storagelocation/<int:pk>/edit', storage_locations.StorageLocationEditView.as_view(), name="dataset_storagelocation_edit"),
     # Dataset's Access (Internal access, as opposed to "Shares")
     path('dataset/<int:dataset_pk>/access/add/', AccessCreateView.as_view(), name='dataset_access_add'),
     path('dataset/<int:dataset_pk>/access/remove/<int:access_pk>/', access.remove_access, name='dataset_access_remove'),
-    path('dataset/<int:dataset_pk>/access/<int:pk>/edit', access.edit_access, name="dataset_access_edit"),
+    path('dataset/<int:dataset_pk>/access/<int:pk>/edit', AccessEditView.as_view(), name="dataset_access_edit"),
     # Dataset's LegalBasis
     path('dataset/<int:dataset_pk>/legalbasis/add/', legalbasis.LegalBasisCreateView.as_view(), name='dataset_legalbasis_add'),
     path('dataset/<int:dataset_pk>/legalbasis/remove/<int:legalbasis_pk>/', legalbasis.remove_legalbasis, name='dataset_legalbasis_remove'),
-    path('dataset/<int:dataset_pk>/legalbasis/<int:pk>/edit', legalbasis.edit_legalbasis, name="dataset_legalbasis_edit"),
+    path('dataset/<int:dataset_pk>/legalbasis/<int:pk>/edit', legalbasis.LegalBasisEditView.as_view(), name="dataset_legalbasis_edit"),
     # Dataset's Shares (External access, as opposed to "Access")
     path('dataset/<int:dataset_pk>/share/add/', share.ShareCreateView.as_view(), name='dataset_share_add'),
     path('dataset/<int:dataset_pk>/share/remove/<int:share_pk>/', share.remove_share, name='dataset_share_remove'),
-    path('dataset/<int:dataset_pk>/share/<int:pk>/edit', share.edit_share, name="dataset_share_edit"),
+    path('dataset/<int:dataset_pk>/share/<int:pk>/edit', share.ShareEditView.as_view(), name="dataset_share_edit"),
 
     # Cohorts
     path('definitions/cohorts/', cohort_list, name="cohorts"),

--- a/web/views/access.py
+++ b/web/views/access.py
@@ -68,7 +68,11 @@ class AccessEditView(CheckerMixin, UpdateView, AjaxViewMixin):
         return obj.dataset
 
     def form_valid(self, form):
-        """If the form is valid, save the associated model and add to the dataset"""
+        """If the form is valid, check that remark is updated then save the associated model and add to the dataset"""
+        if "access_notes" not in form.changed_data:
+            form.add_error("access_notes", "This field must be updated")
+            return super().form_invalid(form)
+
         self.object = form.save(commit=False)
         if not self.request.user.is_anonymous:
             self.object.created_by = self.request.user

--- a/web/views/access.py
+++ b/web/views/access.py
@@ -1,15 +1,19 @@
-from core.forms.access import AccessForm, AccessEditForm
-from web.views.utils import AjaxViewMixin
-from django.views.generic import CreateView
-from core.models import Access, Dataset
-from core.constants import Permissions
-from django.shortcuts import get_object_or_404, redirect, render
+from django.views.generic import CreateView, UpdateView
+from django.shortcuts import get_object_or_404
 from django.contrib import messages
 from django.urls import reverse_lazy
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
+from django.views.decorators.http import require_http_methods
+
+from core.forms.access import AccessForm, AccessEditForm
+from core.models import Access, Dataset
+from core.constants import Permissions
+from core.permissions import CheckerMixin
 from core.permissions import permission_required
 from core.utils import DaisyLogger
-from django.views.decorators.http import require_http_methods
+
+from web.views.utils import AjaxViewMixin
+
 
 log = DaisyLogger(__name__)
 
@@ -37,7 +41,7 @@ class AccessCreateView(CreateView, AjaxViewMixin):
         if not self.request.user.is_anonymous:
             self.object.created_by = self.request.user
         self.object.save()
-        messages.add_message(self.request, messages.SUCCESS, "Access created")
+        messages.add_message(self.request, messages.SUCCESS, 'Access created')
         return super().form_valid(form)
 
     def get_form_kwargs(self):
@@ -52,33 +56,37 @@ class AccessCreateView(CreateView, AjaxViewMixin):
         return super().get_success_url()
 
 
-@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
-def edit_access(request, pk, dataset_pk):
-    access = get_object_or_404(Access, pk=pk)
-    if request.method == 'POST':
-        form = AccessEditForm(request.POST,  request.FILES, instance=access)
-        if form.is_valid():
-            form.save()
-            messages.add_message(request, messages.SUCCESS, "Access definition updated")
-            redirecturl = reverse_lazy('dataset', kwargs={'pk': dataset_pk})
-            return redirect(to=redirecturl, pk=access.id)
-        else:
-            return JsonResponse(
-                {'error':
-                     {'type': 'Edit error', 'messages': [str(e) for e in form.errors]
-                      }}, status=405)
-    else:
-        access.access_notes = None
-        form = AccessEditForm(instance=access)
+class AccessEditView(CheckerMixin, UpdateView, AjaxViewMixin):
+    model = Access
+    template_name = 'accesses/access_form.html'
+    form_class = AccessEditForm
+    permission_required = Permissions.EDIT
 
-    log.debug(submit_url=request.get_full_path())
-    return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path() })
+    def get_permission_object(self, queryset=None):
+        obj = super().get_permission_object()
+        log.debug(obj)
+        return obj.dataset
 
-@require_http_methods(["DELETE"])
+    def form_valid(self, form):
+        """If the form is valid, save the associated model and add to the dataset"""
+        self.object = form.save(commit=False)
+        if not self.request.user.is_anonymous:
+            self.object.created_by = self.request.user
+        self.object.save()
+        messages.add_message(self.request, messages.SUCCESS, 'Access updated')
+        return super().form_valid(form)
+
+    def get_success_url(self, **kwargs):
+        if self.object.dataset:
+            return reverse_lazy('dataset', kwargs={'pk': self.object.dataset.pk})
+        return super().get_success_url()
+
+
+@require_http_methods(['DELETE'])
 @permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
 def remove_access(request, dataset_pk, access_pk):
     access = get_object_or_404(Access, pk=access_pk)
     dataset = get_object_or_404(Dataset, pk=dataset_pk)
     if access.dataset == dataset:
         access.delete()
-    return HttpResponse("Access unlinked")
+    return HttpResponse('Access unlinked')

--- a/web/views/documents.py
+++ b/web/views/documents.py
@@ -1,12 +1,12 @@
 import os
 import unicodedata
 
-
-from django.http import JsonResponse, Http404, HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404 , redirect, render
+from django.http import JsonResponse, Http404, HttpResponse
+from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.http import urlquote
 from django.views.decorators.http import require_http_methods
 from django.contrib import messages
+
 from core.constants import Permissions
 from core.forms import DocumentForm
 from core.models import Document
@@ -62,16 +62,18 @@ def document_edit(request, pk):
     if request.method == 'POST':
         form = DocumentForm(request.POST,  request.FILES, instance=document)
         if form.is_valid():
-            # data = form.cleaned_data
             form.save()
             messages.add_message(request, messages.SUCCESS, "Document updated")
-            redirecturl = document.content_type.name
-            return redirect(to=redirecturl, pk=document.object_id)
+            return JsonResponse({
+                'success': {},
+            })
         else:
-            return JsonResponse(
-                {'error':
-                     {'type': 'Edit error', 'messages': [str(e) for e in form.errors]
-                      }}, status=405)
+            return JsonResponse({
+                'error': {
+                    'type': 'Edit error',
+                    'messages': form.errors,
+                },
+            }, status=405)
     else:
         form = DocumentForm(instance=document)
 

--- a/web/views/legalbasis.py
+++ b/web/views/legalbasis.py
@@ -1,17 +1,19 @@
-
 from django.http import JsonResponse,  HttpResponse
 from django.shortcuts import get_object_or_404 , redirect, render
-from django.views.generic import CreateView
+from django.views.generic import CreateView, UpdateView
 from django.views.decorators.http import require_http_methods
 from django.contrib import messages
 from django.urls import reverse_lazy
+
 from core.forms import LegalBasisForm
 from core.forms.legal_basis import LegalBasisEditForm
 from core.models import LegalBasis, Dataset
-from core.permissions import permission_required
+from core.permissions import permission_required, CheckerMixin
 from core.utils import DaisyLogger
-from web.views.utils import AjaxViewMixin
 from core.constants import Permissions
+
+from web.views.utils import AjaxViewMixin
+
 
 log = DaisyLogger(__name__)
 
@@ -37,7 +39,7 @@ class LegalBasisCreateView(CreateView, AjaxViewMixin):
         if self.dataset:
             self.object.dataset = self.dataset
         self.object.save()
-        messages.add_message(self.request, messages.SUCCESS, "Legal basis definition created.")
+        messages.add_message(self.request, messages.SUCCESS, 'Legal basis definition created.')
         return super().form_valid(form)
 
     def get_form_kwargs(self):
@@ -50,29 +52,25 @@ class LegalBasisCreateView(CreateView, AjaxViewMixin):
         return reverse_lazy('dataset', kwargs={'pk': self.dataset.pk})
 
 
-@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
-def edit_legalbasis(request, pk, dataset_pk):
-    # log.debug('editing legal basis', post=request.POST)
-    legalbasis = get_object_or_404(LegalBasis, pk=pk)
-    if request.method == 'POST':
-        form = LegalBasisEditForm(request.POST,  request.FILES, instance=legalbasis)
-        if form.is_valid():
-            # data = form.cleaned_data
-            form.save()
-            messages.add_message(request, messages.SUCCESS, "Legal basis updated")
-            redirecturl = reverse_lazy('dataset', kwargs={'pk': dataset_pk})
-            return redirect(to=redirecturl, pk=legalbasis.id)
-        else:
-            return JsonResponse(
-                {'error':
-                     {'type': 'Edit error', 'messages': [str(e) for e in form.errors]
-                      }}, status=405)
-    else:
-        form = LegalBasisEditForm(instance=legalbasis)
+class LegalBasisEditView(CheckerMixin, UpdateView, AjaxViewMixin):
+    model = LegalBasis
+    template_name = 'legalbases/legalbasis_form.html'
+    form_class = LegalBasisEditForm
+    permission_required = Permissions.EDIT
 
-    log.debug(submit_url=request.get_full_path())
-    return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path() })
+    def get_permission_object(self):
+        obj = super().get_permission_object()
+        return obj.dataset
 
+    def form_valid(self, form):
+        """If the form is valid, save the associated model and add to the dataset"""
+        self.object = form.save(commit=False)
+        self.object.save()
+        messages.add_message(self.request, messages.SUCCESS, 'Legal basis definition updated.')
+        return super().form_valid(form)
+
+    def get_success_url(self, **kwargs):
+        return reverse_lazy('dataset', kwargs={'pk': self.object.dataset.pk})
 
 
 @require_http_methods(["DELETE"])

--- a/web/views/share.py
+++ b/web/views/share.py
@@ -5,7 +5,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.generic import CreateView, UpdateView
 from django.shortcuts import get_object_or_404 , redirect, render
 
-from core.forms.share import ShareForm, shareFormFactory, ShareFormEdit
+from core.forms.share import ShareForm, shareFormFactory, ShareEditForm
 from core.models import Share, Dataset, Partner
 from core.constants import Permissions
 from core.permissions import permission_required, CheckerMixin
@@ -58,7 +58,7 @@ class ShareCreateView(CreateView, AjaxViewMixin):
 class ShareEditView(CheckerMixin, UpdateView, AjaxViewMixin):
     model = Share
     template_name = 'shares/share_form.html'
-    form_class = ShareFormEdit
+    form_class = ShareEditForm
     permission_required = Permissions.EDIT
 
     def get_permission_object(self):

--- a/web/views/share.py
+++ b/web/views/share.py
@@ -2,43 +2,19 @@ from django.contrib import messages
 from django.http import HttpResponse, JsonResponse
 from django.urls import reverse_lazy
 from django.views.decorators.http import require_http_methods
-from django.views.generic import CreateView
+from django.views.generic import CreateView, UpdateView
 from django.shortcuts import get_object_or_404 , redirect, render
 
 from core.forms.share import ShareForm, shareFormFactory, ShareFormEdit
 from core.models import Share, Dataset, Partner
 from core.constants import Permissions
-from core.permissions import permission_required
-from web.views.utils import AjaxViewMixin
+from core.permissions import permission_required, CheckerMixin
 from core.utils import DaisyLogger
+
+from web.views.utils import AjaxViewMixin
 
 
 log = DaisyLogger(__name__)
-
-
-@permission_required(Permissions.EDIT, (Dataset, 'pk', 'dataset_pk'))
-def edit_share(request, pk, dataset_pk):
-    # log.debug('editing share', post=request.POST)
-    share = get_object_or_404(Share, pk=pk)
-    if request.method == 'POST':
-        form = ShareFormEdit(request.POST,  request.FILES, instance=share)
-        if form.is_valid():
-            # data = form.cleaned_data
-            form.save()
-            messages.add_message(request, messages.SUCCESS, "Logbook entry updated")
-            redirecturl = reverse_lazy('dataset', kwargs={'pk': dataset_pk})
-            return redirect(to=redirecturl, pk=share.id)
-        else:
-            return JsonResponse(
-                {'error':
-                     {'type': 'Edit error', 'messages': [str(e) for e in form.errors]
-                      }}, status=405)
-    else:
-        form = ShareFormEdit(instance=share)
-
-    log.debug(submit_url=request.get_full_path())
-    return render(request, 'modal_form.html', {'form': form, 'submit_url': request.get_full_path() })
-
 
 
 class ShareCreateView(CreateView, AjaxViewMixin):
@@ -64,7 +40,7 @@ class ShareCreateView(CreateView, AjaxViewMixin):
             self.object.dataset = self.dataset
 
         self.object.save()
-        messages.add_message(self.request, messages.SUCCESS, "Data logbook entry created")
+        messages.add_message(self.request, messages.SUCCESS, 'Data logbook entry created')
         return super().form_valid(form)
 
     def get_form(self, form_class=None):
@@ -76,6 +52,35 @@ class ShareCreateView(CreateView, AjaxViewMixin):
     def get_success_url(self, **kwargs):
         if self.dataset:
             return reverse_lazy('dataset', kwargs={'pk': self.dataset.pk})
+        return super().get_success_url()
+
+
+class ShareEditView(CheckerMixin, UpdateView, AjaxViewMixin):
+    model = Share
+    template_name = 'shares/share_form.html'
+    form_class = ShareFormEdit
+    permission_required = Permissions.EDIT
+
+    def get_permission_object(self):
+        obj = super().get_permission_object()
+        return obj.dataset
+
+    def form_valid(self, form):
+        """If the form is valid, save the associated model and add to the dataset"""
+        self.object = form.save(commit=False)
+        self.object.save()
+        messages.add_message(self.request, messages.SUCCESS, 'Data logbook entry updated')
+        return super().form_valid(form)
+
+    def get_form(self, form_class=None):
+        partner = self.request.GET.get('partner', None)
+        if partner is not None:
+            partner = get_object_or_404(Partner, pk=int(partner))
+        return shareFormFactory(partner=partner, dataset=self.object.dataset, **self.get_form_kwargs())
+
+    def get_success_url(self, **kwargs):
+        if self.object.dataset:
+            return reverse_lazy('dataset', kwargs={'pk': self.object.dataset.pk})
         return super().get_success_url()
 
 


### PR DESCRIPTION
Handle the modal EditForms with Ajax in order to display the form errors directly in the modal.

Also force the field "Remarks" in AccessForm to be updated for the form to be valid.

NB: `python manage.py collectstatic` (or `docker-compose exec web python manage.py collectstatic`) may need to be called for the changes to take effect. 