### PR TITLE
Correcting accesses permissions

### DIFF
--- a/core/permissions/checker.py
+++ b/core/permissions/checker.py
@@ -156,7 +156,7 @@ class AccessChecker(AbstractChecker):
 
     def _check(self, perm, obj, **kwargs):
         parent_dataset = obj.dataset
-        if self.user_or_group.is_part_of(constants.Groups.DATA_STEWARD.value) \
+        if self.user_or_group.groups.filter(name=constants.Groups.DATA_STEWARD.value).exists() \
                 or parent_dataset.local_custodians.filter(pk=self.user_or_group.pk).exists():
             return True
         else:

--- a/core/permissions/checker.py
+++ b/core/permissions/checker.py
@@ -156,10 +156,12 @@ class AccessChecker(AbstractChecker):
 
     def _check(self, perm, obj, **kwargs):
         parent_dataset = obj.dataset
+        print(f"Checking if user is data steward ({self.user_or_group.is_part_of([constants.Groups.DATA_STEWARD.name])}) "
+              f"or if user is custodian ({parent_dataset.local_custodians.filter(pk=self.user_or_group.pk).exists()})")
+        print(f"User groups: {self.user_or_group.groups.all()}")
         if self.user_or_group.is_part_of([constants.Groups.DATA_STEWARD.name]) \
                 or parent_dataset.local_custodians.filter(pk=self.user_or_group.pk).exists():
             return True
-
         else:
             return False
 

--- a/core/permissions/checker.py
+++ b/core/permissions/checker.py
@@ -156,10 +156,7 @@ class AccessChecker(AbstractChecker):
 
     def _check(self, perm, obj, **kwargs):
         parent_dataset = obj.dataset
-        print(f"Checking if user is data steward ({self.user_or_group.is_part_of([constants.Groups.DATA_STEWARD.name])}) "
-              f"or if user is custodian ({parent_dataset.local_custodians.filter(pk=self.user_or_group.pk).exists()})")
-        print(f"User groups: {self.user_or_group.groups.all()}")
-        if self.user_or_group.is_part_of([constants.Groups.DATA_STEWARD.name]) \
+        if self.user_or_group.is_part_of(constants.Groups.DATA_STEWARD.value) \
                 or parent_dataset.local_custodians.filter(pk=self.user_or_group.pk).exists():
             return True
         else:

--- a/core/tests/test_permissions.py
+++ b/core/tests/test_permissions.py
@@ -2,6 +2,7 @@ import pytest
 
 from core import constants
 from core.permissions import ALL_PERMS, PERMISSION_MAPPING, AutoChecker
+from core.constants import Groups
 from test.factories import *
 
 
@@ -107,7 +108,9 @@ def test_vip_membership_perms(perm, attribute, permissions):
 def test_dataset_entity_permissions(group, entity_factory):
     user = UserFactory(groups=[group()])
     user.save()
-    dataset = DatasetFactory(title="Test")
+    project = ProjectFactory()
+    project.save()
+    dataset = DatasetFactory(title="Test", project=project)
     dataset.save()
 
     new_entity = entity_factory(object_id=dataset.pk) \
@@ -116,7 +119,8 @@ def test_dataset_entity_permissions(group, entity_factory):
 
     new_entity.save()
 
-    if user.is_part_of(DataStewardGroup):
+    if user.is_part_of(DataStewardGroup.name):
+        user.assign_permissions_to_project(project)
         assert user.has_permission_on_object(constants.Permissions.EDIT, new_entity)
     else:
         assert not user.has_permission_on_object(constants.Permissions.EDIT, new_entity)
@@ -137,7 +141,8 @@ def test_project_entity_permissions(group, entity_factory):
     new_entity = entity_factory(object_id=project.pk)
     new_entity.save()
 
-    if user.is_part_of(DataStewardGroup):
+    if user.is_part_of(DataStewardGroup.name):
+        user.assign_permissions_to_project(project)
         assert user.has_permission_on_object(constants.Permissions.EDIT, new_entity)
     else:
         assert not user.has_permission_on_object(constants.Permissions.EDIT, new_entity)

--- a/web/views/access.py
+++ b/web/views/access.py
@@ -25,9 +25,7 @@ class AccessCreateView(CreateView, AjaxViewMixin):
     form_class = AccessForm
 
     def has_permissions(self, user, dataset):
-        print(f"Is user a data steward: {user.is_part_of([Groups.DATA_STEWARD.name])}")
-        print(f"User is custodian: {dataset.local_custodians.filter(pk=user.pk).exists()}")
-        if user.is_part_of([Groups.DATA_STEWARD.name]):
+        if user.is_part_of(Groups.DATA_STEWARD.value):
             return True
         else:
             return dataset.local_custodians.filter(pk=user.pk).exists()


### PR DESCRIPTION
Only data-stewards and dataset local custodians can now create or edit accesses for that dataset.

Previously, anyone able to see a dataset was able to create new accesses (not edit them though).