### PR TITLE
Draft: Fix access validation

### DIFF
--- a/core/models/access.py
+++ b/core/models/access.py
@@ -190,7 +190,7 @@ class Access(CoreModel):
         if self.status != StatusChoices.active:
             return False
 
-        if self.grant_expires_on is not None and self.grant_expires_on < datetime.now():
+        if self.grant_expires_on is not None and self.grant_expires_on < datetime.date(datetime.now()):
             return False
 
         return True


### PR DESCRIPTION
The line https://github.com/elixir-luxembourg/daisy/blob/60339d6f7ec2516e9a59db7edbd1b3814dc45bce/core/models/access.py#L193 would fail with error (cannot compare `date` and  `datetime`)

Once resolved internally, the validation condition could have less **or equal** operator
