### PR TITLE
Changing behavior for editing accesses

### DIFF
--- a/web/static/js/daisy.js
+++ b/web/static/js/daisy.js
@@ -148,7 +148,7 @@ $(document).ready(function () {
                 var modalForm = modal.find('form');
                 modalForm.submit(function (e) {
                     // remove is-invalid classes and feedback
-                    modalForm.find(".invalid-feedback").remove();
+                    modal.find(".invalid-feedback").remove();
                     modalForm.find(".form-control").removeClass('is-invalid');
                     e.preventDefault();
                     $.ajax({

--- a/web/static/js/daisy.js
+++ b/web/static/js/daisy.js
@@ -171,9 +171,17 @@ $(document).ready(function () {
                         error: function (response) {
                             var errors = response.responseJSON;
                             for (var i in errors) {
-                                var input = modalForm.find('[name=' + i + ']');
-                                input.addClass('is-invalid');
-                                input.after($('<div class="invalid-feedback">' + errors[i] + '</div>'));
+                                if (i === '__all__'){
+                                    errors[i].map( (error) => {
+                                        modalForm.after(
+                                            $('<div class="invalid-feedback d-block">' + error + '</div>')
+                                        );
+                                    })}
+                                else {
+                                    var input = modalForm.find('[name=' + i + ']');
+                                    input.addClass('is-invalid');
+                                    input.after($('<div class="invalid-feedback">' + errors[i] + '</div>'));
+                                }
                             }
                         }
                     });

--- a/web/tests/views/test_access_views.py
+++ b/web/tests/views/test_access_views.py
@@ -1,6 +1,7 @@
 import pytest
 from django.shortcuts import reverse
 
+from guardian.shortcuts import assign_perm
 from core.constants import Permissions
 from core.models.access import Access
 from core.models.user import User
@@ -23,14 +24,13 @@ def check_access_view_permissions(url: str, user: User, obj: Union[Access, Datas
     else:
         assert not user.has_permission_on_object(f'core.{Permissions.EDIT.value}_dataset', obj)
 
-    check_response_status(url, user, [f'core.{Permissions.EDIT.value}_dataset', f'core.{Permissions.PROTECTED.value}_dataset'], method=method, obj=obj)
+    check_response_status(url, user, [f'core.{Permissions.EDIT.value}_dataset'], method=method, obj=obj)
 
     if user.is_part_of(VIPGroup()):
         user.save()
-        parent_dataset.local_custodians.add(user)
-        parent_dataset.save()
+        assign_perm(f'core.{Permissions.EDIT.value}_dataset', user, parent_dataset)
         assert user.has_permission_on_object(f'core.{Permissions.EDIT.value}_dataset', obj)
-        check_response_status(url, user, [f'core.{Permissions.EDIT.value}_dataset', f'core.{Permissions.PROTECTED.value}_dataset'], method=method, obj=obj)
+        check_response_status(url, user, [f'core.{Permissions.EDIT.value}_dataset'], method=method, obj=obj)
 
 
 @pytest.mark.parametrize('group', [VIPGroup, DataStewardGroup, LegalGroup, AuditorGroup])

--- a/web/views/access.py
+++ b/web/views/access.py
@@ -90,6 +90,11 @@ class AccessEditView(CheckerMixin, UpdateView, AjaxViewMixin):
     permission_target = 'dataset'
 
     def form_valid(self, form):
+        """If access status is Active, only data stewards can edit it"""
+        if self.object.status == StatusChoices.active and not self.request.user.is_part_of(Groups.DATA_STEWARD.value):
+            form.add_error(None, "Only data stewards can edit active accesses, please contact one")
+            return super().form_invalid(form)
+
         """If the form is valid, check that remark is updated then save the associated model and add to the dataset"""
         if "access_notes" not in form.changed_data:
             form.add_error("access_notes", "Changes must be justified. Please update this field")

--- a/web/views/access.py
+++ b/web/views/access.py
@@ -28,10 +28,11 @@ class AccessCreateView(CreateView, AjaxViewMixin):
     permission_target = 'dataset'
 
     def has_permissions(self, user, dataset):
-        if user.is_part_of(Groups.DATA_STEWARD.value):
-            return True
-        else:
-            return dataset.local_custodians.filter(pk=user.pk).exists()
+        return (
+            user.is_part_of(Groups.DATA_STEWARD.value) or
+            user.can_edit_dataset(dataset)
+        )
+
 
     def get(self, request, *args, **kwargs):
         dataset = get_object_or_404(Dataset, pk=kwargs['dataset_pk'])


### PR DESCRIPTION
Changed the rules to edit accesses:

- Now, anyone with EDIT permission on a dataset can can modify its accesses. Previously, only data stewards and local custodians could access the form to edit accesses
- Now, only data stewards can modify active accesses. There was no specific protection for active accesses previously