### PR TITLE
Upgrading django and django dependencies;

### DIFF
--- a/core/importer/JSONSchemaValidator.py
+++ b/core/importer/JSONSchemaValidator.py
@@ -66,10 +66,10 @@ class BaseJSONSchemaValidator:
             return self._load_schema_from_disk(schema_name)
         except Exception as e:
             import os
-            logger.warn("Error (1/2) loading schema from disk for JSON validation...: " + str(e))
-            logger.warn("Working directory = " + os.getcwd())
-            logger.warn("File path = " + os.path.join(self.base_path, schema_name))
-            logger.warn("Will try to load the schema from URL...")
+            logger.warning("Error (1/2) loading schema from disk for JSON validation...: " + str(e))
+            logger.warning("Working directory = " + os.getcwd())
+            logger.warning("File path = " + os.path.join(self.base_path, schema_name))
+            logger.warning("Will try to load the schema from URL...")
 
         try:
             return self._load_schema_from_url(schema_name)

--- a/core/importer/base_importer.py
+++ b/core/importer/base_importer.py
@@ -67,7 +67,7 @@ class BaseImporter:
             return self.can_process_object(object)
         except:
             message = f'Couldn\'t check if the imported object has same "$schema" as the importer ({self.__class__.__name__}: {self.json_schema_uri}) - something went wrong while parsing the file'
-            self.logger.warn(message)
+            self.logger.warning(message)
             return False
 
     def can_process_object(self, json_object: Dict) -> bool:
@@ -156,13 +156,13 @@ class BaseImporter:
             object.publish(save=True)
             result = True
         except AttributeError as e:
-            self.logger.warn(f'Publishing this type of entity ({object._meta.object_name}) is not implemented - item is not published.')
+            self.logger.warning(f'Publishing this type of entity ({object._meta.object_name}) is not implemented - item is not published.')
             result = False
         return result
 
     def process_contacts(self, contacts_list: List[Dict]):
         if not isinstance(contacts_list, list):
-            self.logger.warn('Contact list is not a list... Please check the imported file.')
+            self.logger.warning('Contact list is not a list... Please check the imported file.')
             return [], [], []
         
         local_custodians = []

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
     from distutils.core import setup
 
 requirements = [
-    'Django==3.2.19',
+    'Django==3.2.20',
     'django-auth-ldap==4.1.0',
 
     'celery==5.2.3',
@@ -20,12 +20,12 @@ requirements = [
     'xlsxwriter==1.2.9',
 
     'django-model-utils==4.2.0',
-    'django-sequences==2.2',
+    'django-sequences==2.6',
     'django-enumchoicefield==3.0',
 
     'django-compressor==2.2',
     'django-debug-toolbar==3.2.1',
-    'django-formtools==2.1',
+    'django-formtools==2.4.1',
     'django-widget-tweaks==1.4.3',
     'django-countries==7.3.2',
     
@@ -34,15 +34,15 @@ requirements = [
     'django-guardian==2.4.0',
     'django-stronghold==0.3.0',
     'gunicorn==19.9.0',
-    'ipython==7.16.3',
-    'ontobio==2.8.3',
+    'ipython==8.10.0',
+    'ontobio==2.8.8',
     'yamldown>=0.1.8',
     'psycopg2-binary==2.9.3',
     'pysolr==3.8.1',
     'pytest-runner==5.1',
     'python-keycloak==2.6.0',
     'pytz==2022.1',
-    'requests==2.25.1',
+    'requests==2.31.0',
     'urllib3==1.26.5',
     'setuptools-scm==3.3.3',
     'jsonschema==3.2.0',


### PR DESCRIPTION
Upgrading Django to 3.2.20, requests to 2.31, and ipython to 8.10 to solve security issues

Solving deprecation warnings related to upgrades to Django 4.0 (for future upgrades):
-  request.is_ajax() was replaced by newly implemented method is_ajax_request(request: HttpRequest). Implementation follows [django recommendations](https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.HttpRequest.is_ajax) 
- Replacing logger.warn() by logger.warning()
- Upgrading some dependencies:
  - django-sequences: 2.2 => 2.6
  - django-formtools: 2.1 => 2.4.1
  - ontobio: 2.8.3 => 2.8.8
