### PR TITLE
prevent duplicated access requests creation from rems #431

### DIFF
--- a/core/lcsb/rems.py
+++ b/core/lcsb/rems.py
@@ -36,7 +36,10 @@ else:
     synchronizer = DummyAccountSynchronizer()
 
 
-def check_existence_automatic(item):
+def check_existence_automatic(item: Dict[str, str]) -> bool:
+    """
+    Checks if an active access automatically created for the same received data already exists
+    """
     application, resource, user_oidc_id, email, expiration_date = extract_rems_data(item)
     filter_oidc = Q(user__oidc_id=user_oidc_id) | Q(contact__oidc_id=user_oidc_id)
     filter_resource_and_status = Q(dataset__elu_accession=resource, grant_expires_on=expiration_date, status=StatusChoices.active)
@@ -89,6 +92,9 @@ def handle_rems_callback(request: HttpRequest) -> bool:
 
 
 def extract_rems_data(data: Dict[str, str]) -> Tuple[str, str, str, str, date]:
+    """
+    Extracts the data from the REMS request
+    """
     application = data.get('application')
     resource = data.get('resource')
     user_oidc_id = data.get('user')

--- a/core/lcsb/rems.py
+++ b/core/lcsb/rems.py
@@ -11,8 +11,11 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 
 from core.synchronizers import DummyAccountSynchronizer
-from core.lcsb.oidc import get_keycloak_config_from_settings, KeycloakSynchronizationMethod, \
-    CachedKeycloakAccountSynchronizer
+from core.lcsb.oidc import (
+    get_keycloak_config_from_settings,
+    KeycloakSynchronizationMethod,
+    CachedKeycloakAccountSynchronizer,
+)
 from core.models.access import Access, StatusChoices
 from core.models.contact import Contact
 from core.models.dataset import Dataset
@@ -22,15 +25,15 @@ from django.db.models import Q
 
 logger = DaisyLogger(__name__)
 
-if getattr(settings, 'KEYCLOAK_INTEGRATION', False) == True:
+if getattr(settings, "KEYCLOAK_INTEGRATION", False) == True:
     urllib3.disable_warnings()
     keycloak_config = get_keycloak_config_from_settings()
     try:
         keycloak_backend = KeycloakSynchronizationMethod(keycloak_config)
         synchronizer = CachedKeycloakAccountSynchronizer(keycloak_backend)
     except Exception as ex:
-        logger.error(f'Keycloak integration failed to initialize!  {ex}')
-        logger.error('Falling back to the dummy synchronizer...')
+        logger.error(f"Keycloak integration failed to initialize!  {ex}")
+        logger.error("Falling back to the dummy synchronizer...")
         synchronizer = DummyAccountSynchronizer()
 else:
     synchronizer = DummyAccountSynchronizer()
@@ -40,13 +43,20 @@ def check_existence_automatic(item: Dict[str, str]) -> bool:
     """
     Checks if an active access automatically created for the same received data already exists
     """
-    application, resource, user_oidc_id, email, expiration_date = extract_rems_data(item)
+    application, resource, user_oidc_id, email, expiration_date = extract_rems_data(
+        item
+    )
     filter_oidc = Q(user__oidc_id=user_oidc_id) | Q(contact__oidc_id=user_oidc_id)
-    filter_resource_and_status = Q(dataset__elu_accession=resource, grant_expires_on=expiration_date, status=StatusChoices.active)
-    existing_accesses = Access.objects.filter(filter_resource_and_status & filter_oidc).all()
-    if not existing_accesses:
-        return False
+    filter_resource_and_status = Q(
+        dataset__elu_accession=resource,
+        grant_expires_on=expiration_date,
+        status=StatusChoices.active,
+    )
+    existing_accesses = Access.objects.filter(
+        filter_resource_and_status & filter_oidc
+    ).all()
     return any([a.was_generated_automatically for a in existing_accesses])
+
 
 def handle_rems_callback(request: HttpRequest) -> bool:
     """
@@ -58,13 +68,16 @@ def handle_rems_callback(request: HttpRequest) -> bool:
     :returns: True if everything was processed, False if not
     """
 
-    logger.debug('REMS :: Unpacking the data received from REMS...')
-    body_unicode = request.body.decode('utf-8')
+    logger.debug("REMS :: Unpacking the data received from REMS...")
+    body_unicode = request.body.decode("utf-8")
 
     try:
         request_post_data = json.loads(body_unicode)
     except:
-        message = f'REMS :: Received data in wrong format, because deserializing request''s POST body failed!)!'
+        message = (
+            f"REMS :: Received data in wrong format, because deserializing request"
+            "s POST body failed!)!"
+        )
         raise ValueError(message)
 
     if not isinstance(request_post_data, list):
@@ -73,21 +86,33 @@ def handle_rems_callback(request: HttpRequest) -> bool:
         raise TypeError(message)
     # check if accesses already exist for the received data and eventually update them
     # if all accesses already exist, return True and stop processing to avoid triggering again the synchronizer
-    logger.debug('REMS :: check if accesses automatically created already exists for the received data...')
-    already_existing_accesses = {index for index, item in enumerate(request_post_data) if
-                                 check_existence_automatic(item)}
+    logger.debug(
+        "REMS :: check if accesses automatically created already exists for the received data..."
+    )
+    already_existing_accesses = {
+        index
+        for index, item in enumerate(request_post_data)
+        if check_existence_automatic(item)
+    }
     if len(already_existing_accesses) == len(request_post_data):
         # all accesses already exist, stopping processing
-        logger.debug('REMS :: all accesses already exists, noop, stopping processing.')
+        logger.debug("REMS :: all accesses already exists, noop, stopping processing.")
         return True
 
-    logger.debug('REMS :: some accesses do not exist yet')
+    logger.debug("REMS :: some accesses do not exist yet")
     # Ensure the most recent account information by pulling it from Keycloak
-    logger.debug('REMS :: requesting refreshing the account information from Keycloak Synchronizer...')
+    logger.debug(
+        "REMS :: requesting refreshing the account information from Keycloak Synchronizer..."
+    )
     synchronizer.synchronize()
-    logger.debug('REMS :: ...assuming that the OIDC account information has been synchronized')
-    statuses = [handle_rems_entitlement(item) for index, item in enumerate(request_post_data) if
-                index not in already_existing_accesses]
+    logger.debug(
+        "REMS :: ...assuming that the OIDC account information has been synchronized"
+    )
+    statuses = [
+        handle_rems_entitlement(item)
+        for index, item in enumerate(request_post_data)
+        if index not in already_existing_accesses
+    ]
     return all(statuses)
 
 
@@ -95,11 +120,11 @@ def extract_rems_data(data: Dict[str, str]) -> Tuple[str, str, str, str, date]:
     """
     Extracts the data from the REMS request
     """
-    application = data.get('application')
-    resource = data.get('resource')
-    user_oidc_id = data.get('user')
-    email = data.get('mail')
-    expiration_date = data.get('end')
+    application = data.get("application")
+    resource = data.get("resource")
+    user_oidc_id = data.get("user")
+    email = data.get("mail")
+    expiration_date = data.get("end")
 
     if expiration_date is None:
         expiration_date = build_default_expiration_date()
@@ -107,13 +132,14 @@ def extract_rems_data(data: Dict[str, str]) -> Tuple[str, str, str, str, date]:
         expiration_date = isoparse(expiration_date).date()
 
     logger.debug(
-        f'REMS :: * data access request id: {application}, user_oidc_id: {user_oidc_id}, user_email: {email}, resource: {resource}')
+        f"REMS :: * data access request id: {application}, user_oidc_id: {user_oidc_id}, user_email: {email}, resource: {resource}"
+    )
     return application, resource, user_oidc_id, email, expiration_date
 
 
 def build_default_expiration_date():
     return date.today() + timedelta(
-        days=getattr(settings, 'ACCESS_DEFAULT_EXPIRATION_DAYS', 90)
+        days=getattr(settings, "ACCESS_DEFAULT_EXPIRATION_DAYS", 90)
     )
 
 
@@ -123,12 +149,14 @@ def handle_rems_entitlement(data: Dict[str, str]) -> bool:
 
     :returns: True if the user was found and the entitlement processed, False if not
     """
-    application, resource, user_oidc_id, email, expiration_date = extract_rems_data(data)
+    application, resource, user_oidc_id, email, expiration_date = extract_rems_data(
+        data
+    )
     try:
         Dataset.objects.get(elu_accession=resource)
     except Dataset.DoesNotExist:
-        message = f'REMS :: Dataset with such `elu_accession` ({resource}) does not exist! Quitting'
-        logger.error(f' * {message}')
+        message = f"REMS :: Dataset with such `elu_accession` ({resource}) does not exist! Quitting"
+        logger.error(f" * {message}")
         # TODO: E2E: Save and display a notification to DataStewards
         raise ValueError(message)
 
@@ -143,43 +171,57 @@ def handle_rems_entitlement(data: Dict[str, str]) -> bool:
     users_by_email = User.objects.filter(email=email)
     contacts_by_email = Contact.objects.filter(email=email)
 
-    logger.debug(f'REMS :: Locating the User/Contact for the given Access information...')
+    logger.debug(
+        f"REMS :: Locating the User/Contact for the given Access information..."
+    )
 
     if users_by_oidc.count() + contacts_by_oidc.count() > 1:
-        logger.error(f'REMS :: error, found multiple users or contacts with given OIDC_ID: {user_oidc_id}!')
+        logger.error(
+            f"REMS :: error, found multiple users or contacts with given OIDC_ID: {user_oidc_id}!"
+        )
         # Something is wrong - there are multiple users or contacts with given OIDC ID
         # TODO: E2E: Save and display a notification to DataStewards
         return False
 
     if users_by_oidc.count() == 1:
-        logger.debug(f'REMS :: OK, found a user with given OIDC_ID')
+        logger.debug(f"REMS :: OK, found a user with given OIDC_ID")
         user = users_by_oidc.first()
-        return create_rems_entitlement(user, application, resource, user_oidc_id, email, expiration_date)
-    logger.debug(f'REMS :: no users with given OIDC_ID')
+        return create_rems_entitlement(
+            user, application, resource, user_oidc_id, email, expiration_date
+        )
+    logger.debug(f"REMS :: no users with given OIDC_ID")
 
     if contacts_by_oidc.count() == 1:
         contact = contacts_by_oidc.first()
-        logger.debug(f'REMS :: OK, found a contact with given OIDC_ID')
-        return create_rems_entitlement(contact, application, resource, user_oidc_id, email, expiration_date)
-    logger.debug(f'REMS :: no contacts with given OIDC_ID')
+        logger.debug(f"REMS :: OK, found a contact with given OIDC_ID")
+        return create_rems_entitlement(
+            contact, application, resource, user_oidc_id, email, expiration_date
+        )
+    logger.debug(f"REMS :: no contacts with given OIDC_ID")
 
     if users_by_email.count() + contacts_by_email.count() > 1:
-        logger.error(f'REMS :: error, found multiple users or contacts with given email: {email}!')
+        logger.error(
+            f"REMS :: error, found multiple users or contacts with given email: {email}!"
+        )
         # Something is wrong - there are multiple users or contacts with given OIDC ID
         # TODO: E2E: Save and display a notification to DataStewards
         return False
 
     if users_by_email.count() == 1:
-        logger.debug(f'REMS :: OK, found a user with given email')
+        logger.debug(f"REMS :: OK, found a user with given email")
         user = users_by_email.first()
-        return create_rems_entitlement(user, application, resource, user_oidc_id, email, expiration_date)
-    logger.debug(f'REMS :: no users with given email')
+        return create_rems_entitlement(
+            user, application, resource, user_oidc_id, email, expiration_date
+        )
+    logger.debug(f"REMS :: no users with given email")
 
     if contacts_by_email.count() == 1:
         contact = contacts_by_email.first()
-        logger.debug(f'REMS :: OK, found a contact with given email')
-        return create_rems_entitlement(contact, application, resource, user_oidc_id, email, expiration_date)
-    logger.debug(f'REMS :: no contacts with given email')
+        logger.debug(f"REMS :: OK, found a contact with given email")
+        return create_rems_entitlement(
+            contact, application, resource, user_oidc_id, email, expiration_date
+        )
+    logger.debug(f"REMS :: no contacts with given email")
 
     # At this moment, we didn't find any User nor Contact with given OIDC_ID nor email
     # Will attempt to create a new contact then
@@ -189,19 +231,22 @@ def handle_rems_entitlement(data: Dict[str, str]) -> bool:
     return True
 
 
-def create_rems_entitlement(obj: Union[Access, User],
-                            application: str,
-                            dataset_id: str,
-                            user_oidc_id: str,
-                            email: str,
-                            expiration_date: date) -> bool:
+def create_rems_entitlement(
+    obj: Union[Access, User],
+    application: str,
+    dataset_id: str,
+    user_oidc_id: str,
+    email: str,
+    expiration_date: date,
+) -> bool:
     """
     Tries to find a dataset with `elu_accession` equal to `dataset_id`.
     If it exists, it will add a new logbook entry (Access object) set to the current user/contact
     Assumes that the Dataset exists, otherwise will throw an exception.
     """
     dataset = Dataset.objects.get(elu_accession=dataset_id)
-    notes, system_rems_user = build_access_notes_and_rems_user(application)
+    notes = build_access_notes_rems(application)
+    system_rems_user = get_or_create_rems_user()
 
     if type(obj) == User:
         new_logbook_entry = Access(
@@ -227,27 +272,36 @@ def create_rems_entitlement(obj: Union[Access, User],
         )
     else:
         klass = obj.__class__.__name__
-        raise TypeError(f'Wrong type of the object - should be Contact or User, is: {klass} instead')
+        raise TypeError(
+            f"Wrong type of the object - should be Contact or User, is: {klass} instead"
+        )
 
     new_logbook_entry.save()
     return True
 
 
-def build_access_notes_and_rems_user(application):
-    notes = f'Set automatically by REMS data access request #{application}'
-    system_rems_user = User.objects.filter(
-        username='system::REMS'
-    )
+def build_access_notes_rems(application: str) -> str:
+    """
+    Build and return note to be attached to the access created from a REMS application
+    """
+    return f"Set automatically by REMS data access request #{application}"
+
+
+def get_or_create_rems_user() -> User:
+    """
+    Check if rems system user already exists and either return it directly or create it and return it
+    """
+    system_rems_user = User.objects.filter(username="system::REMS")
     # The password is not a hash, therefore it is
     # not possible to log into this account
     if system_rems_user.count() == 0:
         system_rems_user = User.objects.create(
-            username='system::REMS',
-            first_name=':REMS:',
-            last_name=':System Account:',
-            password='this is an invalid hash',
-            email='lcsb-sysadmins+REMS@uni.lu'
+            username="system::REMS",
+            first_name=":REMS:",
+            last_name=":System Account:",
+            password="this is an invalid hash",
+            email="lcsb-sysadmins+REMS@uni.lu",
         )
     else:
         system_rems_user = system_rems_user.first()
-    return notes, system_rems_user
+    return system_rems_user

--- a/core/lcsb/rems.py
+++ b/core/lcsb/rems.py
@@ -4,23 +4,23 @@ import urllib3
 
 from datetime import datetime, date, timedelta
 from dateutil.parser import isoparse
-from typing import Dict, Union
+from typing import Dict, Union, Tuple
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 
 from core.synchronizers import DummyAccountSynchronizer
-from core.lcsb.oidc import get_keycloak_config_from_settings, KeycloakSynchronizationMethod, CachedKeycloakAccountSynchronizer
+from core.lcsb.oidc import get_keycloak_config_from_settings, KeycloakSynchronizationMethod, \
+    CachedKeycloakAccountSynchronizer
 from core.models.access import Access, StatusChoices
 from core.models.contact import Contact
 from core.models.dataset import Dataset
 from core.models.user import User
 from core.utils import DaisyLogger
-
+from django.db.models import Q
 
 logger = DaisyLogger(__name__)
-
 
 if getattr(settings, 'KEYCLOAK_INTEGRATION', False) == True:
     urllib3.disable_warnings()
@@ -31,10 +31,19 @@ if getattr(settings, 'KEYCLOAK_INTEGRATION', False) == True:
     except Exception as ex:
         logger.error(f'Keycloak integration failed to initialize!  {ex}')
         logger.error('Falling back to the dummy synchronizer...')
-        synchronizer = DummyAccountSynchronizer()    
+        synchronizer = DummyAccountSynchronizer()
 else:
     synchronizer = DummyAccountSynchronizer()
 
+
+def check_existence_automatic(item):
+    application, resource, user_oidc_id, email, expiration_date = extract_rems_data(item)
+    filter_oidc = Q(user__oidc_id=user_oidc_id) | Q(contact__oidc_id=user_oidc_id)
+    filter_resource_and_status = Q(dataset__elu_accession=resource, grant_expires_on=expiration_date, status=StatusChoices.active)
+    existing_accesses = Access.objects.filter(filter_resource_and_status & filter_oidc).all()
+    if not existing_accesses:
+        return False
+    return any([a.was_generated_automatically for a in existing_accesses])
 
 def handle_rems_callback(request: HttpRequest) -> bool:
     """
@@ -45,11 +54,6 @@ def handle_rems_callback(request: HttpRequest) -> bool:
 
     :returns: True if everything was processed, False if not
     """
-
-    # Ensure the most recent account inforrmation by pulling it from Keycloak
-    logger.debug('REMS :: Requesting refreshing the account information from Keycloak Synchronizer...')
-    synchronizer.synchronize()
-    logger.debug('REMS :: ...assuming that the OIDC account information has been synchronized')
 
     logger.debug('REMS :: Unpacking the data received from REMS...')
     body_unicode = request.body.decode('utf-8')
@@ -64,16 +68,27 @@ def handle_rems_callback(request: HttpRequest) -> bool:
         the_type = type(request_post_data)
         message = f'REMS :: Received data with wrong format (it is not a list, but "{the_type}" instead)!'
         raise TypeError(message)
+    # check if accesses already exist for the received data and eventually update them
+    # if all accesses already exist, return True and stop processing to avoid triggering again the synchronizer
+    logger.debug('REMS :: check if accesses automatically created already exists for the received data...')
+    already_existing_accesses = {index for index, item in enumerate(request_post_data) if
+                                 check_existence_automatic(item)}
+    if len(already_existing_accesses) == len(request_post_data):
+        # all accesses already exist, stopping processing
+        logger.debug('REMS :: all accesses already exists, noop, stopping processing.')
+        return True
 
-    statuses = [handle_rems_entitlement(item) for item in request_post_data]
+    logger.debug('REMS :: some accesses do not exist yet')
+    # Ensure the most recent account information by pulling it from Keycloak
+    logger.debug('REMS :: requesting refreshing the account information from Keycloak Synchronizer...')
+    synchronizer.synchronize()
+    logger.debug('REMS :: ...assuming that the OIDC account information has been synchronized')
+    statuses = [handle_rems_entitlement(item) for index, item in enumerate(request_post_data) if
+                index not in already_existing_accesses]
     return all(statuses)
 
-def handle_rems_entitlement(data: Dict[str, str]) -> bool:
-    """
-    Handles a single information about the entitlement from REMS.
 
-    :returns: True if the user was found and the entitlement processed, False if not
-    """
+def extract_rems_data(data: Dict[str, str]) -> Tuple[str, str, str, str, date]:
     application = data.get('application')
     resource = data.get('resource')
     user_oidc_id = data.get('user')
@@ -81,14 +96,28 @@ def handle_rems_entitlement(data: Dict[str, str]) -> bool:
     expiration_date = data.get('end')
 
     if expiration_date is None:
-        expiration_date = date.today() + timedelta(
-            days=getattr(settings, 'ACCESS_DEFAULT_EXPIRATION_DAYS', 90)
-        )
+        expiration_date = build_default_expiration_date()
     else:
         expiration_date = isoparse(expiration_date).date()
 
-    logger.debug(f'REMS :: * data access request id: {application}, user_oidc_id: {user_oidc_id}, user_email: {email}, resource: {resource}')
+    logger.debug(
+        f'REMS :: * data access request id: {application}, user_oidc_id: {user_oidc_id}, user_email: {email}, resource: {resource}')
+    return application, resource, user_oidc_id, email, expiration_date
 
+
+def build_default_expiration_date():
+    return date.today() + timedelta(
+        days=getattr(settings, 'ACCESS_DEFAULT_EXPIRATION_DAYS', 90)
+    )
+
+
+def handle_rems_entitlement(data: Dict[str, str]) -> bool:
+    """
+    Handles a single piece of information about the entitlement from REMS.
+
+    :returns: True if the user was found and the entitlement processed, False if not
+    """
+    application, resource, user_oidc_id, email, expiration_date = extract_rems_data(data)
     try:
         Dataset.objects.get(elu_accession=resource)
     except Dataset.DoesNotExist:
@@ -96,7 +125,7 @@ def handle_rems_entitlement(data: Dict[str, str]) -> bool:
         logger.error(f' * {message}')
         # TODO: E2E: Save and display a notification to DataStewards
         raise ValueError(message)
-    
+
     # First, tries to find a user with given OIDC ID
     # Then, it tries to find a contact with given OIDC ID
     # Then, it tries to find a user with given email address
@@ -109,7 +138,6 @@ def handle_rems_entitlement(data: Dict[str, str]) -> bool:
     contacts_by_email = Contact.objects.filter(email=email)
 
     logger.debug(f'REMS :: Locating the User/Contact for the given Access information...')
-    
 
     if users_by_oidc.count() + contacts_by_oidc.count() > 1:
         logger.error(f'REMS :: error, found multiple users or contacts with given OIDC_ID: {user_oidc_id}!')
@@ -146,7 +174,7 @@ def handle_rems_entitlement(data: Dict[str, str]) -> bool:
         logger.debug(f'REMS :: OK, found a contact with given email')
         return create_rems_entitlement(contact, application, resource, user_oidc_id, email, expiration_date)
     logger.debug(f'REMS :: no contacts with given email')
-    
+
     # At this moment, we didn't find any User nor Contact with given OIDC_ID nor email
     # Will attempt to create a new contact then
     Contact.get_or_create_from_rems(email, user_oidc_id)
@@ -155,37 +183,19 @@ def handle_rems_entitlement(data: Dict[str, str]) -> bool:
     return True
 
 
-def create_rems_entitlement(obj: Union[Access, User], 
-        application: str, 
-        dataset_id: str, 
-        user_oidc_id: str, 
-        email: str,
-        expiration_date: date) -> bool:
+def create_rems_entitlement(obj: Union[Access, User],
+                            application: str,
+                            dataset_id: str,
+                            user_oidc_id: str,
+                            email: str,
+                            expiration_date: date) -> bool:
     """
     Tries to find a dataset with `elu_accession` equal to `dataset_id`.
     If it exists, it will add a new logbook entry (Access object) set to the current user/contact
     Assumes that the Dataset exists, otherwise will throw an exception.
     """
-    notes = f'Set automatically by REMS data access request #{application}'
-
     dataset = Dataset.objects.get(elu_accession=dataset_id)
-
-    system_rems_user = User.objects.filter(
-        username='system::REMS'
-    )
-
-    # The password is not a hash, therefore it is
-    # not possible to log into this account
-    if system_rems_user.count() == 0:
-        system_rems_user = User.objects.create(
-            username='system::REMS',
-            first_name=':REMS:',
-            last_name=':System Account:',
-            password='this is an invalid hash',
-            email='lcsb-sysadmins+REMS@uni.lu'
-        )
-    else:
-        system_rems_user = system_rems_user.first()
+    notes, system_rems_user = build_access_notes_and_rems_user(application)
 
     if type(obj) == User:
         new_logbook_entry = Access(
@@ -212,6 +222,26 @@ def create_rems_entitlement(obj: Union[Access, User],
     else:
         klass = obj.__class__.__name__
         raise TypeError(f'Wrong type of the object - should be Contact or User, is: {klass} instead')
-        
+
     new_logbook_entry.save()
     return True
+
+
+def build_access_notes_and_rems_user(application):
+    notes = f'Set automatically by REMS data access request #{application}'
+    system_rems_user = User.objects.filter(
+        username='system::REMS'
+    )
+    # The password is not a hash, therefore it is
+    # not possible to log into this account
+    if system_rems_user.count() == 0:
+        system_rems_user = User.objects.create(
+            username='system::REMS',
+            first_name=':REMS:',
+            last_name=':System Account:',
+            password='this is an invalid hash',
+            email='lcsb-sysadmins+REMS@uni.lu'
+        )
+    else:
+        system_rems_user = system_rems_user.first()
+    return notes, system_rems_user

--- a/core/models/partner.py
+++ b/core/models/partner.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.apps import apps
 from django.db import models
 from django_countries.fields import CountryField
@@ -5,7 +6,6 @@ from django_countries.fields import CountryField
 from model_utils import Choices
 from .utils import CoreTrackedDBModel, TextFieldWithInputWidget
 
-from elixir_daisy import settings
 
 GEO_CATEGORY = Choices(
     ('EU', 'EU'),

--- a/core/models/project.py
+++ b/core/models/project.py
@@ -10,7 +10,7 @@ from core.permissions.mapping import PERMISSION_MAPPING
 from .utils import CoreTrackedModel, COMPANY
 from .partner import  HomeOrganisation
 
-from elixir_daisy import settings
+from django.conf import settings
 
 
 class Project(CoreTrackedModel):

--- a/core/tests/test_lcsb.py
+++ b/core/tests/test_lcsb.py
@@ -7,10 +7,11 @@ from typing import Dict, List
 from core.models import User
 from core.models.access import StatusChoices
 from core.lcsb.oidc import KeycloakAccountSynchronizer, KeycloakSynchronizationMethod
-from core.lcsb.rems import create_rems_entitlement
+from core.lcsb.rems import create_rems_entitlement, extract_rems_data, build_default_expiration_date, \
+    check_existence_automatic
 from core.models.access import Access
 from core.models.contact import Contact
-from test.factories import ContactFactory, DatasetFactory, UserFactory, ExposureFactory, EndpointFactory
+from test.factories import ContactFactory, DatasetFactory, UserFactory, ExposureFactory, EndpointFactory, AccessFactory
 from web.views.utils import get_user_or_contact_by_oidc_id
 
 
@@ -20,53 +21,53 @@ class KeycloakAdminConnectionMock:
 
     def get_users(self, query) -> List[Dict]:
         return [{
-            "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", 
-            "createdTimestamp": 1634231689999, 
-            "username": "0000-0001-2222-3333", 
-            "enabled": True, 
-            "totp": False, 
-            "emailVerified": True, 
-            "firstName": "TESTY", 
-            "lastName": "MCTesty", 
+            "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "createdTimestamp": 1634231689999,
+            "username": "0000-0001-2222-3333",
+            "enabled": True,
+            "totp": False,
+            "emailVerified": True,
+            "firstName": "TESTY",
+            "lastName": "MCTesty",
             "email": "testy.mctesty@uni.lu",
-            "disableableCredentialTypes": [], 
-            "requiredActions": [], 
+            "disableableCredentialTypes": [],
+            "requiredActions": [],
             "notBefore": 0,
             "access": {
-                "manageGroupMembership": False, 
-                "view": True, 
+                "manageGroupMembership": False,
+                "view": True,
                 "mapRoles": False,
-                "impersonate": False, 
+                "impersonate": False,
                 "manage": False
             }
         }, {
-            "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeef", 
-            "createdTimestamp": 1634231689998, 
-            "username": "0000-0001-2222-3334", 
-            "enabled": True, 
-            "totp": False, 
-            "emailVerified": True, 
-            "firstName": "BOBBY", 
-            "lastName": "FISCHER", 
+            "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeef",
+            "createdTimestamp": 1634231689998,
+            "username": "0000-0001-2222-3334",
+            "enabled": True,
+            "totp": False,
+            "emailVerified": True,
+            "firstName": "BOBBY",
+            "lastName": "FISCHER",
             "email": "bobby.fischer@gmail.com",
-            "disableableCredentialTypes": [], 
-            "requiredActions": [], 
+            "disableableCredentialTypes": [],
+            "requiredActions": [],
             "notBefore": 0,
             "access": {
-                "manageGroupMembership": False, 
-                "view": True, 
+                "manageGroupMembership": False,
+                "view": True,
                 "mapRoles": False,
-                "impersonate": False, 
+                "impersonate": False,
                 "manage": False
             }
         }, {
-            "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeeg", 
-            "createdTimestamp": 1634231689997, 
-            "username": "0000-0001-2222-3335", 
-            "firstName": "Ann", 
-            "lastName": "Bann", 
+            "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeeg",
+            "createdTimestamp": 1634231689997,
+            "username": "0000-0001-2222-3335",
+            "firstName": "Ann",
+            "lastName": "Bann",
         }]
-    
+
 
 class KeycloakSynchronizationMethodMock(KeycloakSynchronizationMethod):
     def test_connection(self) -> bool:
@@ -83,17 +84,104 @@ class KeycloakSynchronizationMethodMock(KeycloakSynchronizationMethod):
     def get_keycloak_admin_connection(self) -> None:
         return KeycloakAdminConnectionMock()
 
-    def _create_connection(self, config:Dict=None) -> KeycloakAdminConnectionMock:
+    def _create_connection(self, config: Dict = None) -> KeycloakAdminConnectionMock:
         return KeycloakAdminConnectionMock()
 
 
 def test_keycloak_synchronization_config_validation():
     with pytest.raises(KeyError):
         kc = KeycloakSynchronizationMethod({})
-    
+
     with pytest.raises(KeyError):
         kc = KeycloakSynchronizationMethod({}, False)
         kc._create_connection({})
+
+
+def test_extract_rems_data_empty_expiration():
+    application_id = 4056
+    resource_id = "TEST-2-5591E3-1"
+    user_oidc_id = "4ce4f280-8095-4a20-bf19-6426d2292134"
+    email = "john.doe@uni.lu"
+    data = {"application": application_id, "resource": resource_id, "user": user_oidc_id,
+            "mail": email, "end": None}
+    application, resource, user_oidc_id, email, expiration_date = extract_rems_data(data)
+    assert application == application_id
+    assert resource == resource_id
+    assert user_oidc_id == user_oidc_id
+    assert email == email
+    assert expiration_date == build_default_expiration_date()
+
+
+def test_extract_rems_data_with_expiration():
+    application_id = 4056
+    resource_id = "TEST-2-5591E3-1"
+    user_oidc_id = "4ce4f280-8095-4a20-bf19-6426d2292134"
+    email = "john.doe@uni.lu"
+    data = {"application": application_id, "resource": resource_id, "user": user_oidc_id,
+            "mail": email, "end": "2023-08-03T23:59:59.000Z"}
+    application, resource, user_oidc_id, email, expiration_date = extract_rems_data(data)
+    assert application == application_id
+    assert resource == resource_id
+    assert user_oidc_id == user_oidc_id
+    assert email == email
+    assert expiration_date == datetime.date(2023, 8, 3)
+
+
+def test_check_existence_automatic_positive():
+    resource_id = "TEST-2-5591E3-1"
+    expiration_date = datetime.date.today() + datetime.timedelta(days=1)
+    user = UserFactory(oidc_id='12345', email='example@example.org')
+    user.save()
+    dataset = DatasetFactory(title='Test', local_custodians=[user], elu_accession=resource_id)
+    dataset.save()
+    create_rems_entitlement(user, 'Test Application', resource_id, user.oidc_id, user.email, expiration_date)
+    application_id = 4056
+    email = "john.doe@uni.lu"
+    data = {"application": application_id, "resource": resource_id, "user": user.oidc_id,
+            "mail": email, "end": expiration_date.strftime('%Y-%m-%d') + "T23:59:59.000Z"}
+    assert check_existence_automatic(data)
+
+
+def test_check_existence_automatic_negative_mismatch():
+    resource_id = "TEST-2-5591E3-1"
+    expiration_date = datetime.date.today() + datetime.timedelta(days=1)
+    user = UserFactory(oidc_id='12345', email='example@example.org')
+    user.save()
+    dataset = DatasetFactory(title='Test', local_custodians=[user], elu_accession=resource_id)
+    dataset.save()
+    create_rems_entitlement(user, 'Test Application', resource_id, user.oidc_id, user.email, expiration_date)
+    application_id = 4056
+    email = "john.doe@uni.lu"
+    # resource id is different
+    data = {"application": application_id, "resource": "TEST-2-5591E3-2", "user": user.oidc_id,
+            "mail": email, "end": expiration_date.strftime('%Y-%m-%d') + "T23:59:59.000Z"}
+    assert not check_existence_automatic(data)
+    # user id is different
+    data = {"application": application_id, "resource": resource_id, "user": "xxx",
+            "mail": email, "end": expiration_date.strftime('%Y-%m-%d') + "T23:59:59.000Z"}
+    assert not check_existence_automatic(data)
+    # expiration date is different
+    data = {"application": application_id, "resource": resource_id, "user": user.oidc_id,
+            "mail": email, "end": datetime.date.today().strftime('%Y-%m-%d') + "T23:59:59.000Z"}
+    assert not check_existence_automatic(data)
+
+def test_check_existence_automatic_negative_manually_created():
+    resource_id = "TEST-2-5591E3-1"
+    expiration_date = datetime.date.today() + datetime.timedelta(days=1)
+    email = "john.doe@uni.lu"
+    user = UserFactory(oidc_id='12345', email=email)
+    user.save()
+    dataset = DatasetFactory(title='Test', local_custodians=[user], elu_accession=resource_id)
+    dataset.save()
+    access = AccessFactory(dataset=dataset, user=user)
+    access.grant_expires_on=expiration_date
+    access.was_generated_automatically = False
+    access.status = StatusChoices.active
+    access.save()
+    application_id = 4056
+    data = {"application": application_id, "resource": resource_id, "user": user.oidc_id,
+            "mail": email, "end": expiration_date.strftime('%Y-%m-%d') + "T23:59:59.000Z"}
+    assert not check_existence_automatic(data)
 
 
 def test_add_rems_entitlements():
@@ -130,10 +218,11 @@ def test_permissions():
 
     access2 = Access(access_notes='Access user', user=user, dataset=dataset, status=StatusChoices.active)
     access2.save()
-    
+
     assert '123' in user.get_access_permissions()
     assert '123' in contact.get_access_permissions()
     assert len(user2.get_access_permissions()) == 0
+
 
 def test_get_user_or_contact_by_oidc_id():
     user_found, contact_found, user, contact = get_user_or_contact_by_oidc_id('0')

--- a/elixir_daisy/settings_ci.py
+++ b/elixir_daisy/settings_ci.py
@@ -61,3 +61,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
 
 DEBUG = True
+
+REMS_INTEGRATION_ENABLED = True
+REMS_ALLOWED_IP_ADDRESSES = ['127.0.0.1']

--- a/elixir_daisy/settings_compose.py
+++ b/elixir_daisy/settings_compose.py
@@ -60,8 +60,6 @@ CELERY_BROKER_URL = 'amqp://guest:guest@mq:5672//'
 CELERY_RESULT_BACKEND = 'django-db'
 
 TESTING = os.environ.get('TEST', False)
-REMS_INTEGRATION_ENABLED = True
-REMS_ALLOWED_IP_ADDRESSES = ['*']
 
 # import also local settings
 try:

--- a/elixir_daisy/settings_compose.py
+++ b/elixir_daisy/settings_compose.py
@@ -60,6 +60,8 @@ CELERY_BROKER_URL = 'amqp://guest:guest@mq:5672//'
 CELERY_RESULT_BACKEND = 'django-db'
 
 TESTING = os.environ.get('TEST', False)
+REMS_INTEGRATION_ENABLED = True
+REMS_ALLOWED_IP_ADDRESSES = ['*']
 
 # import also local settings
 try:

--- a/elixir_daisy/settings_compose_ci.py
+++ b/elixir_daisy/settings_compose_ci.py
@@ -32,6 +32,8 @@ CELERY_RESULT_BACKEND = 'django-db'
 
 TESTING = True
 GLOBAL_API_KEY = os.environ.get('GLOBAL_API_KEY', 'default_global_api_key_in_settings_compose_ci.py')
+REMS_INTEGRATION_ENABLED = True
+REMS_ALLOWED_IP_ADDRESSES = ['*']
 
 try:
     from .settings_ci import *

--- a/elixir_daisy/settings_compose_ci.py
+++ b/elixir_daisy/settings_compose_ci.py
@@ -30,7 +30,7 @@ CELERY_BROKER_URL = 'amqp://guest:guest@mq:5672//'
 ## Result backend
 CELERY_RESULT_BACKEND = 'django-db'
 
-TESTING = os.environ.get('TEST', False)
+TESTING = True
 GLOBAL_API_KEY = os.environ.get('GLOBAL_API_KEY', 'default_global_api_key_in_settings_compose_ci.py')
 
 try:

--- a/elixir_daisy/settings_tests.py
+++ b/elixir_daisy/settings_tests.py
@@ -10,7 +10,7 @@ DATABASES = {
         'USER': 'daisy_test',
         'PASSWORD': 'daisy_test',
         'HOST': 'localhost',
-        'PORT': 5432,
+        'PORT': 5433,
     }
 }
 
@@ -54,3 +54,6 @@ CELERY_BROKER_URL = 'amqp://guest:guest@mq:5672//'
 
 ## Result backend
 CELERY_RESULT_BACKEND = 'django-db'
+
+REMS_INTEGRATION_ENABLED = True
+REMS_ALLOWED_IP_ADDRESSES = ['*']

--- a/elixir_daisy/settings_tests.py
+++ b/elixir_daisy/settings_tests.py
@@ -10,7 +10,7 @@ DATABASES = {
         'USER': 'daisy_test',
         'PASSWORD': 'daisy_test',
         'HOST': 'localhost',
-        'PORT': 5433,
+        'PORT': 5432,
     }
 }
 

--- a/web/tests/test_rems.py
+++ b/web/tests/test_rems.py
@@ -7,10 +7,13 @@ from django.shortcuts import reverse
 
 import datetime
 
+from django.conf import settings
 from test.factories import UserFactory, DatasetFactory, AccessFactory
 
 log = DaisyLogger(__name__)
 
+settings.REMS_INTEGRATION_ENABLED = True
+settings.REMS_ALLOWED_IP_ADDRESSES = ['*']
 
 def test_rems_handler_duplicate(client, user_vip, user_data_steward):
     resource_id = "TEST-2-5591E3-1"

--- a/web/tests/test_rems.py
+++ b/web/tests/test_rems.py
@@ -25,11 +25,11 @@ def test_rems_handler_duplicate(client, user_vip, user_data_steward):
             "mail": email, "end": expiration_date.strftime('%Y-%m-%d') + "T23:59:59.000Z"}]
 
     response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
-    assert response.status_code == 200
+    assert response.status_code == 200, response.content
     accesses = Access.objects.filter(dataset=dataset, user=user).all()
     assert len(accesses) == 1
     response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
-    assert response.status_code == 200
+    assert response.status_code == 200 , response.content
     accesses = Access.objects.filter(dataset=dataset, user=user).all()
     assert len(accesses) == 1
 
@@ -45,11 +45,11 @@ def test_rems_handler_no_expiration(client, user_vip, user_data_steward):
              "mail": email, "end": None}]
 
     response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
-    assert response.status_code == 200
+    assert response.status_code == 200, response.content
     accesses = Access.objects.filter(dataset=dataset, user=user).all()
     assert len(accesses) == 1
     response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
-    assert response.status_code == 200
+    assert response.status_code == 200, response.content
     accesses = Access.objects.filter(dataset=dataset, user=user).all()
     assert len(accesses) == 1
 
@@ -67,11 +67,11 @@ def test_rems_handler_different_expiration(client, user_vip, user_data_steward):
              "mail": email, "end": expiration_date_1.strftime('%Y-%m-%d') + "T23:59:59.000Z"}]
 
     response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
-    assert response.status_code == 200
+    assert response.status_code == 200, response.content
     accesses = Access.objects.filter(dataset=dataset, user=user).all()
     assert len(accesses) == 1
     data[0]['end'] = expiration_date_2.strftime('%Y-%m-%d') + "T23:59:59.000Z"
     response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
-    assert response.status_code == 200
+    assert response.status_code == 200, response.content
     accesses = Access.objects.filter(dataset=dataset, user=user).all()
     assert len(accesses) == 2

--- a/web/tests/test_rems.py
+++ b/web/tests/test_rems.py
@@ -1,0 +1,77 @@
+import json
+
+from core.models import Access
+from core.utils import DaisyLogger
+
+from django.shortcuts import reverse
+
+import datetime
+
+from test.factories import UserFactory, DatasetFactory, AccessFactory
+
+log = DaisyLogger(__name__)
+
+
+def test_rems_handler_duplicate(client, user_vip, user_data_steward):
+    resource_id = "TEST-2-5591E3-1"
+    expiration_date = datetime.date.today() + datetime.timedelta(days=1)
+    email = "john.doe@uni.lu"
+    user = UserFactory(oidc_id='12345', email=email)
+    user.save()
+    dataset = DatasetFactory(title='Test', local_custodians=[user], elu_accession=resource_id)
+    dataset.save()
+    application_id = 4056
+    data = [{"application": application_id, "resource": resource_id, "user": user.oidc_id,
+            "mail": email, "end": expiration_date.strftime('%Y-%m-%d') + "T23:59:59.000Z"}]
+
+    response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
+    assert response.status_code == 200
+    accesses = Access.objects.filter(dataset=dataset, user=user).all()
+    assert len(accesses) == 1
+    response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
+    assert response.status_code == 200
+    accesses = Access.objects.filter(dataset=dataset, user=user).all()
+    assert len(accesses) == 1
+
+def test_rems_handler_no_expiration(client, user_vip, user_data_steward):
+    resource_id = "TEST-2-5591E3-1"
+    email = "john.doe@uni.lu"
+    user = UserFactory(oidc_id='12345', email=email)
+    user.save()
+    dataset = DatasetFactory(title='Test', local_custodians=[user], elu_accession=resource_id)
+    dataset.save()
+    application_id = 4056
+    data = [{"application": application_id, "resource": resource_id, "user": user.oidc_id,
+             "mail": email, "end": None}]
+
+    response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
+    assert response.status_code == 200
+    accesses = Access.objects.filter(dataset=dataset, user=user).all()
+    assert len(accesses) == 1
+    response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
+    assert response.status_code == 200
+    accesses = Access.objects.filter(dataset=dataset, user=user).all()
+    assert len(accesses) == 1
+
+def test_rems_handler_different_expiration(client, user_vip, user_data_steward):
+    resource_id = "TEST-2-5591E3-1"
+    expiration_date_1 = datetime.date.today() + datetime.timedelta(days=1)
+    expiration_date_2 = datetime.date.today() + datetime.timedelta(days=2)
+    email = "john.doe@uni.lu"
+    user = UserFactory(oidc_id='12345', email=email)
+    user.save()
+    dataset = DatasetFactory(title='Test', local_custodians=[user], elu_accession=resource_id)
+    dataset.save()
+    application_id = 4056
+    data = [{"application": application_id, "resource": resource_id, "user": user.oidc_id,
+             "mail": email, "end": expiration_date_1.strftime('%Y-%m-%d') + "T23:59:59.000Z"}]
+
+    response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
+    assert response.status_code == 200
+    accesses = Access.objects.filter(dataset=dataset, user=user).all()
+    assert len(accesses) == 1
+    data[0]['end'] = expiration_date_2.strftime('%Y-%m-%d') + "T23:59:59.000Z"
+    response = client.post(reverse('api_rems_endpoint'), json.dumps(data), content_type="application/json")
+    assert response.status_code == 200
+    accesses = Access.objects.filter(dataset=dataset, user=user).all()
+    assert len(accesses) == 2

--- a/web/tests/test_rems.py
+++ b/web/tests/test_rems.py
@@ -7,13 +7,9 @@ from django.shortcuts import reverse
 
 import datetime
 
-from django.conf import settings
 from test.factories import UserFactory, DatasetFactory, AccessFactory
 
 log = DaisyLogger(__name__)
-
-settings.REMS_INTEGRATION_ENABLED = True
-settings.REMS_ALLOWED_IP_ADDRESSES = ['*']
 
 def test_rems_handler_duplicate(client, user_vip, user_data_steward):
     resource_id = "TEST-2-5591E3-1"

--- a/web/views/api.py
+++ b/web/views/api.py
@@ -23,7 +23,6 @@ from core.lcsb.rems import synchronizer
 from core.models import User, Cohort, Dataset, Partner, Project, DiseaseTerm, Contact, Endpoint
 from core.models.term_model import TermCategory, PhenotypeTerm, StudyTerm, GeneTerm
 from core.utils import DaisyLogger
-from elixir_daisy import settings
 from web.views.utils import get_client_ip, get_user_or_contact_by_oidc_id
 
 
@@ -248,7 +247,7 @@ def rems_endpoint(request):
         message = f'REMS - something is wrong with the configuration!'
         more = str(ex)
         logger.debug(f'{message} ({more})')
-        return create_error_response(message+more)
+        return create_error_response(message)
     except Exception as ex:
         message = f'REMS - something went wrong during the import!'
         more = str(ex)

--- a/web/views/api.py
+++ b/web/views/api.py
@@ -248,7 +248,7 @@ def rems_endpoint(request):
         message = f'REMS - something is wrong with the configuration!'
         more = str(ex)
         logger.debug(f'{message} ({more})')
-        return create_error_response(message)
+        return create_error_response(message+more)
     except Exception as ex:
         message = f'REMS - something went wrong during the import!'
         more = str(ex)

--- a/web/views/api.py
+++ b/web/views/api.py
@@ -248,7 +248,7 @@ def rems_endpoint(request):
         message = f'REMS - something is wrong with the configuration!'
         more = str(ex)
         logger.debug(f'{message} ({more})')
-        return create_error_response(ex.message)
+        return create_error_response(message)
     except Exception as ex:
         message = f'REMS - something went wrong during the import!'
         more = str(ex)
@@ -307,4 +307,3 @@ def permissions(request, user_oidc_id: str) -> JsonResponse:
             {'more': more},
             status=404
         )
-    


### PR DESCRIPTION
When receiving a request to /api/rems we now check and ignore the items received if we already have active accesses created automatically for the same user, same dataset and same expiration date.