### PR TITLE
#455 - Removing scientific metadata field for non data stewards

### DIFF
--- a/core/forms/__init__.py
+++ b/core/forms/__init__.py
@@ -11,6 +11,7 @@ from .data_declaration import (
     DataDeclarationSubFormFromExisting,
 )
 from .document import DocumentForm
+from .project import ProjectForm
 from .partner import PartnerForm
 from .permission import UserPermFormSet
 from .legal_basis import LegalBasisForm
@@ -35,6 +36,7 @@ __all__ = [
     "PartnerForm",
     "LegalBasisForm",
     "PartnerRoleForm",
+    "ProjectForm",
     "UserPermFormSet",
     "PublicationForm",
     "ShareForm",

--- a/core/forms/dataset.py
+++ b/core/forms/dataset.py
@@ -53,10 +53,13 @@ class DatasetForm(forms.ModelForm):
         heading_help = "Provide basic information for the new dataset."
 
     def __init__(self, *args, **kwargs):
-        dataset = None
-        if "dataset" in kwargs:
-            dataset = kwargs.pop("dataset")
+        kwargs.pop("dataset", None)
+        keep_metadata = kwargs.pop("keep_metadata_field", False)
+
         super().__init__(*args, **kwargs)
+        if not keep_metadata:
+            del self.fields["scientific_metadata"]
+
         self.fields["local_custodians"].queryset = User.objects.exclude(
             username="AnonymousUser"
         )

--- a/core/forms/project.py
+++ b/core/forms/project.py
@@ -51,7 +51,10 @@ class ProjectForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         kwargs["label_suffix"] = ""
+        keep_metadata_field = kwargs.pop("keep_metadata_field", False)
         super().__init__(*args, **kwargs)
+        if not keep_metadata_field:
+            del self.fields["scientific_metadata"]
         instance = kwargs.get("instance", None)
 
         if "data" not in kwargs:

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -160,6 +160,9 @@ class User(AbstractUser):
     def can_publish(self):
         return self.is_superuser or self.is_part_of(constants.Groups.DATA_STEWARD.value)
 
+    def can_edit_metadata(self):
+        return self.is_part_of(constants.Groups.DATA_STEWARD.value)
+
     # Permission management
     # ======================================================================
 

--- a/web/views/datasets.py
+++ b/web/views/datasets.py
@@ -1,11 +1,11 @@
 from django.conf import settings
-from django.shortcuts import render, redirect, get_object_or_404
+from django.shortcuts import render, get_object_or_404
 from django.urls import reverse_lazy
 from django.contrib import messages
 from django.views.generic import CreateView, DetailView, UpdateView, DeleteView
+from django.http import HttpResponseRedirect
 from formtools.wizard.views import NamedUrlSessionWizardView
-from django.http import HttpResponseRedirect, Http404
-from core.constants import Permissions
+
 from core.forms.storage_location import StorageLocationForm
 from core.forms import DatasetForm, DataDeclarationForm, LegalBasisForm, AccessForm
 from core.forms.dataset import DatasetFormEdit
@@ -13,9 +13,10 @@ from core.models import Dataset, Exposure
 from core.models.utils import COMPANY
 from core.permissions import CheckerMixin
 from core.utils import DaisyLogger
-from core.constants import Permissions, Groups
+from core.constants import Permissions
 from . import facet_view_utils
-from typing import List, Tuple, Union, Any, Dict
+
+from typing import Any, Dict
 
 log = DaisyLogger(__name__)
 

--- a/web/views/datasets.py
+++ b/web/views/datasets.py
@@ -78,7 +78,7 @@ class DatasetWizardView(NamedUrlSessionWizardView):
                 Dataset, pk=self.storage.extra_data.get("dataset_id")
             )
             kwargs["dataset"] = dataset
-        elif self.request.user.is_part_of(Groups.DATA_STEWARD.value):
+        elif self.request.user.can_edit_metadata():
             # If the user is a data steward, we want to keep the scientific metadata field
             kwargs["keep_metadata_field"] = True
 
@@ -162,7 +162,7 @@ class DatasetCreateView(CreateView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        if self.request.user.is_part_of(Groups.DATA_STEWARD.value):
+        if self.request.user.can_edit_metadata():
             # If the user is a data steward, we want to keep the scientific metadata field
             kwargs["keep_metadata_field"] = True
         return kwargs
@@ -219,7 +219,7 @@ class DatasetEditView(CheckerMixin, UpdateView):
         kwargs = super().get_form_kwargs()
         kwargs.update({"dataset": self.object})
 
-        if self.request.user.is_part_of(Groups.DATA_STEWARD.value):
+        if self.request.user.can_edit_metadata():
             kwargs.update({"keep_metadata_field": True})
         return kwargs
 

--- a/web/views/projects.py
+++ b/web/views/projects.py
@@ -1,12 +1,11 @@
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.decorators import user_passes_test
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction, IntegrityError
 from django.db.models import Count
 from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404, redirect
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.views.generic import (
     ListView,
     CreateView,
@@ -20,14 +19,12 @@ from core.forms.contract import ContractForm
 from core.forms.dataset import DatasetForm
 from core.forms.project import ProjectForm, DatasetSelection
 from core.models import Project, Contract
+from core.models.utils import COMPANY
 from core.permissions import permission_required
 from core.permissions.checker import CheckerMixin
-from web.views.utils import is_data_steward
 from . import facet_view_utils
 
 FACET_FIELDS = settings.FACET_FIELDS["project"]
-from core.models.utils import COMPANY
-from django.urls import reverse
 
 
 class ProjectListView(ListView):

--- a/web/views/projects.py
+++ b/web/views/projects.py
@@ -88,7 +88,7 @@ class ProjectCreateView(CreateView):
             ):
                 data.update({"local_custodians": str(self.request.user.pk)})
             kwargs.update({"data": data})
-        if self.request.user.is_part_of(Groups.DATA_STEWARD.value):
+        if self.request.user.can_edit_metadata():
             kwargs.update({"keep_metadata_field": True})
         return kwargs
 
@@ -151,7 +151,7 @@ class ProjectEditView(CheckerMixin, UpdateView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        if self.request.user.is_part_of(Groups.DATA_STEWARD.value):
+        if self.request.user.can_edit_metadata():
             kwargs.update({"keep_metadata_field": True})
         return kwargs
 

--- a/web/views/projects.py
+++ b/web/views/projects.py
@@ -88,6 +88,8 @@ class ProjectCreateView(CreateView):
             ):
                 data.update({"local_custodians": str(self.request.user.pk)})
             kwargs.update({"data": data})
+        if self.request.user.is_part_of(Groups.DATA_STEWARD.value):
+            kwargs.update({"keep_metadata_field": True})
         return kwargs
 
     def form_valid(self, form):
@@ -146,6 +148,12 @@ class ProjectEditView(CheckerMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         return context
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if self.request.user.is_part_of(Groups.DATA_STEWARD.value):
+            kwargs.update({"keep_metadata_field": True})
+        return kwargs
 
     def form_valid(self, form):
         response = super().form_valid(form)


### PR DESCRIPTION
Dataset and Project views now set a `keep_metatada_field` in the form kwargs.

If that field is not set with a value of True, the DatasetForm and ProjectForm removes `scientific_metadata` from their fields.