### PR TITLE
Upgrade PostgreSQL from 10.1 to 16.4

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
         command: gunicorn --reload -w 2 -b :5000 --pid /run/gunicorn.pid elixir_daisy.wsgi
     # database
     db:
-        image: postgres:10.1
+        image: postgres:16.4-bullseye
         restart: unless-stopped
         environment:
             POSTGRES_PASSWORD: ${DB_PASSWORD:-daisy}


### PR DESCRIPTION

### How to Test the PostgreSQL Upgrade:

1. **Build and start the updated Docker containers:**

   ```bash
   docker compose up --build
   ```

2. **Restore the legacy backup:**

   - Copy the legacy backup file into the backup container:
     ```bash
     docker cp ../daisy_test.tar.gz $(docker compose ps -q backup):/code/daisy_test.tar.gz
     ```

   - Execute the legacy restore script inside the backup container:
     ```bash
     docker compose exec backup sh /code/scripts/legacy_restore.sh /code/daisy_test.tar.gz
     ```

   - Remove the backup file from the container:
     ```bash
     docker compose exec backup rm /code/daisy_test.tar.gz
     ```

5. **Apply Django migrations:**

   ```bash
   docker compose exec web python manage.py migrate
   ```

6. **Rebuild the Solr index:**

   ```bash
   docker compose exec web python manage.py rebuild_index --noinput
   ```