### PR TITLE
increase client_max_body_size - nginx

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -24,7 +24,7 @@ http {
     # fallback in case we can't determine a type
     default_type application/octet-stream;
     sendfile on;
-
+    client_max_body_size 16m;
     upstream app_server {
             # fail_timeout=0 means we always retry an upstream even if it failed
             # to return a good HTTP response


### PR DESCRIPTION
default limit of 1MB is too low for the documents that need to be uploaded to daisy