### PR TITLE
Fixes #519 - Use Dataset Wizard when creating new dataset from Project context

### DIFF
--- a/core/forms/dataset.py
+++ b/core/forms/dataset.py
@@ -91,7 +91,7 @@ class DatasetForm(forms.ModelForm):
 
         errors = []
         proj = cleaned_data["project"]
-        if proj:
+        if proj and self.instance.pk:
             project_inconsistency = False
             contracts = self.instance.collect_contracts()
             for contract, obj in contracts:

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -13,7 +13,7 @@
     </div>
     <div class="row mt-4">
         <div class="col">
-            {% url 'wizard' as base_url %}
+            {% url 'dataset_wizard' as base_url %}
             {% with dataset_add_url=base_url|add:"?reset=true" %}
             {% include '_includes/card_list.html' with list=last_datasets list_title='My datasets' url_name='dataset' add_new_link=dataset_add_url icon_name='assessment'  %}
             {% endwith %}

--- a/web/templates/projects/choose_dataset_type.html
+++ b/web/templates/projects/choose_dataset_type.html
@@ -10,7 +10,7 @@
     <div class="row">
         {% for type in types %}
             <a class="card col-md-5 btn-secondary btn btn-raised mb-4 ml-4"
-               href="{% url 'project_dataset_create' pk=project.pk flag=type.value %}">
+               href="{% url 'project_dataset_wizard' pk=project.pk %}">
                 <div class="card-body">
                     <h2 class="card-title">{% block card_title %}{{ type }}{% endblock %}</h2>
                 </div>

--- a/web/templates/projects/project.html
+++ b/web/templates/projects/project.html
@@ -193,7 +193,7 @@
             <div class="card-body">
                 {% if can_edit %}
                 <div class="ml-1 float-right btn-group">
-                    <a href="{% url 'datasets_add_to_project' pk=project.pk %}">
+                    <a href="{% url 'project_dataset_wizard' pk=project.pk %}">
                         <button class="btn bmd-btn-fab bmd-btn-fab-sm dropdown-toggle" type="button" title="Add new dataset to project">
                                     <i class="material-icons">add</i>
                                 </button>

--- a/web/tests/test_dataset.py
+++ b/web/tests/test_dataset.py
@@ -14,9 +14,11 @@ from test.factories import (
     DatasetFactory,
     ExposureFactory,
     EndpointFactory,
+    ProjectFactory,
 )
 from django.urls import reverse
 from django.test import Client
+from web.views.datasets import DatasetWizardView
 
 
 def test_get_dataset_add(client_user_normal):
@@ -132,7 +134,7 @@ def test_dataset_wizard_form(
     for step_name, step_data in wizard_test_data.items():
         form_data, Model = step_data
         assert Model.objects.all().count() == 0
-        response = client_user_normal.post(reverse("wizard"), form_data)
+        response = client_user_normal.post(reverse("dataset_wizard"), form_data)
 
         if step_name != "dataset":
             skip_wizard_value = form_data[f"{step_name}-skip_wizard"][0]
@@ -197,3 +199,30 @@ def test_dataset_publication_status_with_mixed_exposures():
     ExposureFactory.create(dataset=dataset, endpoint=endpoint2, is_deprecated=True)
     assert dataset.publication_status == Dataset.ExposureStatus.PUBLISHED
     assert dataset.is_published is True
+
+@pytest.mark.django_db
+def test_dataset_wizard_get_step_url_with_project_context():
+    """Test DatasetWizardView get_step_url includes project pk in URL parameters."""
+    project = ProjectFactory.create()
+    view = DatasetWizardView()
+    view.url_name = "project_dataset_wizard_step"
+    view.kwargs = {"pk": project.id}
+
+    step_url = view.get_step_url("dataset")
+
+    expected_url = reverse(
+        "project_dataset_wizard_step",
+        kwargs={"pk": project.id, "step": "dataset"}
+    )
+    assert step_url == expected_url
+
+
+@pytest.mark.django_db
+def test_dataset_wizard_get_form_initial_with_valid_project():
+    """Test DatasetWizardView get_form_initial correctly adds project context."""
+    project = ProjectFactory.create()
+    view = DatasetWizardView()
+    view.kwargs = {"pk": project.id}
+    view.initial_dict = {}
+    initial = view.get_form_initial("dataset")
+    assert initial["project"] == project.id

--- a/web/tests/test_dataset.py
+++ b/web/tests/test_dataset.py
@@ -200,6 +200,7 @@ def test_dataset_publication_status_with_mixed_exposures():
     assert dataset.publication_status == Dataset.ExposureStatus.PUBLISHED
     assert dataset.is_published is True
 
+
 @pytest.mark.django_db
 def test_dataset_wizard_get_step_url_with_project_context():
     """Test DatasetWizardView get_step_url includes project pk in URL parameters."""
@@ -211,8 +212,7 @@ def test_dataset_wizard_get_step_url_with_project_context():
     step_url = view.get_step_url("dataset")
 
     expected_url = reverse(
-        "project_dataset_wizard_step",
-        kwargs={"pk": project.id, "step": "dataset"}
+        "project_dataset_wizard_step", kwargs={"pk": project.id, "step": "dataset"}
     )
     assert step_url == expected_url
 

--- a/web/urls.py
+++ b/web/urls.py
@@ -113,7 +113,9 @@ from web.views.users import add_personnel_to_project, remove_personnel_from_proj
 from web.views.log_entry import LogEntryListView
 
 dataset_wizard_view = DatasetWizardView.as_view(url_name="dataset_wizard_step")
-project_dataset_wizard_view = DatasetWizardView.as_view(url_name="project_dataset_wizard_step")
+project_dataset_wizard_view = DatasetWizardView.as_view(
+    url_name="project_dataset_wizard_step"
+)
 
 web_urls = [
     # Single pages
@@ -462,8 +464,16 @@ web_urls = [
         name="project_contract_remove",
     ),
     # Project's dataset
-    path("project/<int:pk>/dataset/wizard/<str:step>/", project_dataset_wizard_view, name="project_dataset_wizard_step"),
-    path("project/<int:pk>/dataset/wizard/", project_dataset_wizard_view, name="project_dataset_wizard"),
+    path(
+        "project/<int:pk>/dataset/wizard/<str:step>/",
+        project_dataset_wizard_view,
+        name="project_dataset_wizard_step",
+    ),
+    path(
+        "project/<int:pk>/dataset/wizard/",
+        project_dataset_wizard_view,
+        name="project_dataset_wizard",
+    ),
     path(
         "project/<int:pk>/dataset/add",
         projects.project_dataset_add,

--- a/web/urls.py
+++ b/web/urls.py
@@ -112,7 +112,8 @@ from web.views.user import (
 from web.views.users import add_personnel_to_project, remove_personnel_from_project
 from web.views.log_entry import LogEntryListView
 
-wizard_view = DatasetWizardView.as_view(url_name="wizard_step")
+dataset_wizard_view = DatasetWizardView.as_view(url_name="dataset_wizard_step")
+project_dataset_wizard_view = DatasetWizardView.as_view(url_name="project_dataset_wizard_step")
 
 web_urls = [
     # Single pages
@@ -208,9 +209,8 @@ web_urls = [
         data_declarations.data_dec_paginated_search,
         name="data_dec_paginated_search",
     ),
-    # Datasets
-    path("wizard/<str:step>/", wizard_view, name="wizard_step"),
-    path("wizard/", wizard_view, name="wizard"),
+    path("dataset/wizard/<str:step>/", dataset_wizard_view, name="dataset_wizard_step"),
+    path("dataset/wizard/", dataset_wizard_view, name="dataset_wizard"),
     path("datasets/", dataset_list, name="datasets"),
     path("datasets/export", datasets_export, name="datasets_export"),
     path("dataset/add/", DatasetCreateView.as_view(), name="dataset_add"),
@@ -462,6 +462,8 @@ web_urls = [
         name="project_contract_remove",
     ),
     # Project's dataset
+    path("project/<int:pk>/dataset/wizard/<str:step>/", project_dataset_wizard_view, name="project_dataset_wizard_step"),
+    path("project/<int:pk>/dataset/wizard/", project_dataset_wizard_view, name="project_dataset_wizard"),
     path(
         "project/<int:pk>/dataset/add",
         projects.project_dataset_add,

--- a/web/views/datasets.py
+++ b/web/views/datasets.py
@@ -88,7 +88,7 @@ class DatasetWizardView(NamedUrlSessionWizardView):
     def get_form_initial(self, step: str) -> Dict[str, Any]:
         """Add project context for dataset step."""
         initial = super().get_form_initial(step)
-        project_id = self.kwargs.get("pk")  
+        project_id = self.kwargs.get("pk")
         if step == "dataset" and project_id:
             project = get_object_or_404(Project, pk=int(project_id))
             initial.update({"project": project.id})
@@ -156,9 +156,9 @@ class DatasetWizardView(NamedUrlSessionWizardView):
 
     def get_step_url(self, step):
         """Override to maintain project context in wizard step URLs."""
-        kwargs = {'step': step}
-        if 'pk' in self.kwargs:
-            kwargs['pk'] = self.kwargs['pk']
+        kwargs = {"step": step}
+        if "pk" in self.kwargs:
+            kwargs["pk"] = self.kwargs["pk"]
         return reverse(self.url_name, kwargs=kwargs)
 
 

--- a/web/views/datasets.py
+++ b/web/views/datasets.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.shortcuts import render, get_object_or_404
-from django.urls import reverse_lazy
+from django.urls import reverse_lazy, reverse
 from django.contrib import messages
 from django.views.generic import CreateView, DetailView, UpdateView, DeleteView
 from django.http import HttpResponseRedirect
@@ -9,7 +9,7 @@ from formtools.wizard.views import NamedUrlSessionWizardView
 from core.forms.storage_location import StorageLocationForm
 from core.forms import DatasetForm, DataDeclarationForm, LegalBasisForm, AccessForm
 from core.forms.dataset import DatasetFormEdit
-from core.models import Dataset, Exposure
+from core.models import Dataset, Exposure, Project
 from core.models.utils import COMPANY
 from core.permissions import CheckerMixin
 from core.utils import DaisyLogger
@@ -85,6 +85,16 @@ class DatasetWizardView(NamedUrlSessionWizardView):
 
         return kwargs
 
+    def get_form_initial(self, step: str) -> Dict[str, Any]:
+        """Add project context for dataset step."""
+        initial = super().get_form_initial(step)
+        project_id = self.kwargs.get("pk")  
+        if step == "dataset" and project_id:
+            project = get_object_or_404(Project, pk=int(project_id))
+            initial.update({"project": project.id})
+
+        return initial
+
     def process_step(self, form, **kwargs) -> Dict[str, Any]:
         """
         Processes the form at the current step.
@@ -143,6 +153,13 @@ class DatasetWizardView(NamedUrlSessionWizardView):
         if dataset_id is not None:
             context["dataset_id"] = Dataset.objects.get(pk=dataset_id).id
         return context
+
+    def get_step_url(self, step):
+        """Override to maintain project context in wizard step URLs."""
+        kwargs = {'step': step}
+        if 'pk' in self.kwargs:
+            kwargs['pk'] = self.kwargs['pk']
+        return reverse(self.url_name, kwargs=kwargs)
 
 
 class DatasetCreateView(CreateView):
@@ -251,7 +268,7 @@ def dataset_list(request):
             "title": "Datasets",
             "help_text": Dataset.AppMeta.help_text,
             "search_url": "datasets",
-            "add_url": "wizard",
+            "add_url": "dataset_wizard",
             "data": {"datasets": datasets},
             "results_template_name": "search/_items/datasets.html",
             "company_name": COMPANY,


### PR DESCRIPTION
## Fixes #519 - Use Dataset Wizard when creating new dataset from Project context

### Problem
Creating datasets from project pages used a basic form while the datasets page used a comprehensive wizard, creating inconsistent UX.

### Solution
Unified dataset creation to always use the wizard. When initiated from a project page, the project is automatically pre-selected.

### How to Verify
**From Project:**
1. Go to project page → add new dataset → Should open wizard with project pre-filled

**From Datasets page:**
1. Go to Datasets → add new dataset → Should open same wizard without project