### PR TITLE
fix(settings): make SERVER_URL and SERVER_SCHEME configurable via env

### DIFF
--- a/elixir_daisy/settings.py
+++ b/elixir_daisy/settings.py
@@ -206,8 +206,11 @@ EMAIL_BACKEND = (
 EMAIL_DONOTREPLY = env("EMAIL_DONOTREPLY", default="do-not-reply@daisy.lcsb.uni.lu")
 
 # server settings
-SERVER_SCHEME = "https"
-SERVER_URL = "example.com"
+# Used in exported JSON ("source" field), email notification links and public
+# dataset/DAC URLs, so a production instance must be able to point these at its
+# own host. Defaults preserve the previous hardcoded values for existing setups.
+SERVER_SCHEME = env("SERVER_SCHEME", default="https")
+SERVER_URL = env("SERVER_URL", default="example.com")
 
 HELPDESK_EMAIL = env("HELPDESK_EMAIL", default="support@example.com")
 


### PR DESCRIPTION
## What

Closes #629.

`SERVER_URL` and `SERVER_SCHEME` were hardcoded in `elixir_daisy/settings.py` (`example.com` and `https`), unlike every adjacent setting, which is read via `env()`. Both are actively used across the codebase — in exported JSON payloads (the `source` field), email notification links, and public dataset/DAC URLs — so any production instance was generating links pointing at `example.com` unless the code was manually patched.

## The change

Read both from the environment with the previous hardcoded values as defaults, so existing setups that do not set the variables are unchanged:

```python
# server settings
SERVER_SCHEME = env("SERVER_SCHEME", default="https")
SERVER_URL    = env("SERVER_URL", default="example.com")
```

This is the same `django-environ` pattern already used by `EMAIL_DONOTREPLY`, `HELPDESK_EMAIL`, `LOG_DIR`, etc. directly around these lines.

## Verification

The full suite needs the `postgres + solr + ldap` `docker-compose` stack, which I don't have here, so I verified the settings module in isolation instead:

- **Defaults (env unset) — no behaviour change:** `SERVER_URL='example.com'`, `SERVER_SCHEME='https'` (identical to the old hardcoded values)
- **Override (env set) — config now works:** `SERVER_URL=daisy.example.org SERVER_SCHEME=http` -> both honour the override

Existing importer/model tests that consume `SERVER_URL` (e.g. `core/importer/*_exporter.py`, `notification/email_sender.py`) are unaffected because the defaults match the old values.

Per `CONTRIBUTING.md` (unit tests except for very minor changes), this is a two-line env-with-default change that is behaviour-identical when the vars are unset — happy to add a dedicated settings test if you'd prefer one.