### PR TITLE
prevent user creation during LDAP login

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -129,14 +129,22 @@ def celery_config():
 # thoses users must correspond to those created in the LDAP tree
 @pytest.fixture
 def user_normal(django_user_model):
-    u = django_user_model.objects.create(username="normal.user", password="password")
+    u = django_user_model.objects.create(
+        username="normal.user",
+        email="normal.user@uni.lu",
+        password="password",
+    )
     u.save()
     return u
 
 
 @pytest.fixture
 def user_vip(django_user_model):
-    u = django_user_model.objects.create(username="pi.number1", password="password")
+    u = django_user_model.objects.create(
+        username="pi.number1",
+        email="pi.number1@uni.lu",
+        password="password",
+    )
     g, _ = Group.objects.get_or_create(name=GroupConstants.VIP.value)
     u.groups.add(g)
     return u
@@ -144,7 +152,11 @@ def user_vip(django_user_model):
 
 @pytest.fixture
 def user_data_steward(django_user_model):
-    u = django_user_model.objects.create(username="data.steward", password="password")
+    u = django_user_model.objects.create(
+        username="data.steward",
+        email="data.steward@uni.lu",
+        password="password",
+    )
     g, _ = Group.objects.get_or_create(name=GroupConstants.DATA_STEWARD.value)
     u.groups.add(g)
     return u

--- a/core/importer/ldap_users_importer.py
+++ b/core/importer/ldap_users_importer.py
@@ -8,6 +8,13 @@ from core.importer.users_importer import UsersImporter
 from core.models.user import UserSource
 
 
+class ImportLDAPBackend(LDAPBackend):
+    def __init__(self):
+        super().__init__()
+        self.settings.NO_NEW_USERS = False
+        self.settings.USER_QUERY_FIELD = None
+
+
 class LDAPUsersImporter(UsersImporter):
     def __init__(self, class_filter, username_attribute, search_dn, simple_search=True):
         self.search_dn = search_dn
@@ -19,7 +26,7 @@ class LDAPUsersImporter(UsersImporter):
     # self.username_attribute = settings.LDAP_USERS_IMPORT_USERNAME_ATTR
 
     def import_all_users(self):
-        ldap_backend = LDAPBackend()
+        ldap_backend = ImportLDAPBackend()
         ldap_user = _LDAPUser(ldap_backend, username="")
         ldap_search = LDAPSearch(
             self.search_dn,
@@ -38,7 +45,7 @@ class LDAPUsersImporter(UsersImporter):
             user.save()
 
     def import_from_username(self, username, set_pi=False):
-        ldap_backend = LDAPBackend()
+        ldap_backend = ImportLDAPBackend()
         user = ldap_backend.populate_user(username)
 
         if set_pi:

--- a/core/tests/test_ldap_auth_config.py
+++ b/core/tests/test_ldap_auth_config.py
@@ -61,7 +61,9 @@ def test_ldap_backend_in_authentication_backends():
 @pytest.mark.parametrize("login", ["normal.user", "normal.user@uni.lu"])
 def test_ldap_login_resolves_to_imported_user(django_user_model, login):
     email = "normal.user@uni.lu"
-    imported_user = django_user_model.objects.create(username=email, email=email)
+    imported_user = django_user_model.objects.create(
+        username="normal.user", email=email
+    )
     ldap_user = SimpleNamespace(attrs={"mail": [email]})
 
     user, built = LDAPBackend().get_or_build_user(login, ldap_user)

--- a/core/tests/test_ldap_auth_config.py
+++ b/core/tests/test_ldap_auth_config.py
@@ -1,6 +1,9 @@
+from types import SimpleNamespace
+
 import ldap
 import pytest
 from django.conf import settings
+from django_auth_ldap.backend import LDAPBackend
 from django_auth_ldap.config import LDAPSearchUnion
 
 pytestmark = pytest.mark.skipif(
@@ -41,6 +44,27 @@ def test_auth_ldap_search_count():
         assert len(searches) > 1
 
 
+def test_auth_ldap_user_query_field_is_email():
+    assert settings.AUTH_LDAP_USER_QUERY_FIELD == "email"
+
+
+def test_auth_ldap_does_not_create_users_at_login():
+    assert settings.AUTH_LDAP_NO_NEW_USERS is True
+
+
 @pytest.mark.django_db
 def test_ldap_backend_in_authentication_backends():
     assert "django_auth_ldap.backend.LDAPBackend" in settings.AUTHENTICATION_BACKENDS
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("login", ["normal.user", "normal.user@uni.lu"])
+def test_ldap_login_resolves_to_imported_user(django_user_model, login):
+    email = "normal.user@uni.lu"
+    imported_user = django_user_model.objects.create(username=email, email=email)
+    ldap_user = SimpleNamespace(attrs={"mail": [email]})
+
+    user, built = LDAPBackend().get_or_build_user(login, ldap_user)
+
+    assert user == imported_user
+    assert built is False

--- a/elixir_daisy/settings.py
+++ b/elixir_daisy/settings.py
@@ -466,6 +466,8 @@ if LDAP_ENABLED := env.bool("LDAP_ENABLED", default=False):
         "last_name": "sn",
         "email": "mail",
     }
+    AUTH_LDAP_USER_QUERY_FIELD = "email"
+    AUTH_LDAP_NO_NEW_USERS = True
     LDAP_USERS_IMPORT_CLASS = env("LDAP_USERS_IMPORT_CLASS", default="")
     LDAP_USERS_IMPORT_USERNAME_ATTR = env(
         "LDAP_USERS_IMPORT_USERNAME_ATTR", default="userprincipalname"


### PR DESCRIPTION
- Both login formats now use the same imported account
- Login no longer creates new accounts
- Only the LDAP importer can create accounts
close  #646